### PR TITLE
feat(jungle-addition): Add avatar, difficulty and scoring setup, plus sharing

### DIFF
--- a/projects/jungle-addition/css/styles.css
+++ b/projects/jungle-addition/css/styles.css
@@ -146,6 +146,103 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
 
 @keyframes sway { 0%,100% { transform: rotate(-3deg); } 50% { transform: rotate(3deg); } }
 
+/* ---- setup wizard ---------------------------------------------------------- */
+
+/* Three questions, one screen each. The nav bar is pinned to the bottom so the
+   "next" button lands under the same thumb every step, however tall the step is. */
+.setup-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 22px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.setup-step { flex: 1 1 auto; }
+.setup-step h2 { margin: 0 0 4px; font-size: 1.5rem; color: var(--banana); }
+.setup-note { margin: 0 0 14px; color: var(--mist); font-size: .92rem; line-height: 1.45; }
+
+.setup-dots { display: flex; gap: 8px; justify-content: center; }
+.setup-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: rgba(255, 253, 245, .22);
+  transition: background .2s ease, transform .2s ease;
+}
+.setup-dot.on { background: var(--banana); transform: scale(1.3); }
+
+.setup-nav { display: flex; gap: 10px; align-items: stretch; }
+.setup-nav .big-button { flex: 1 1 auto; }
+
+/* Same grid as the badges, sized for a face rather than an emoji. */
+.avatar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+  gap: 10px;
+}
+
+.avatar-option {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  padding: 10px 6px;
+  border-radius: 18px;
+  background: rgba(255, 253, 245, .1);
+  transition: background .15s ease, transform .1s ease;
+}
+.avatar-option:active { transform: translateY(2px); }
+.avatar-option.selected {
+  background: rgba(126, 217, 87, .2);
+  box-shadow: inset 0 0 0 3px var(--lime);
+}
+
+.avatar-svg { width: 72px; height: 72px; }
+.avatar-name { font-size: .88rem; font-weight: 800; color: var(--cream); }
+
+/* One row per choice, whether it toggles (points) or picks (difficulty). */
+.choice-list { display: flex; flex-direction: column; gap: 10px; }
+
+.choice-row {
+  display: flex; align-items: center; gap: 12px;
+  min-height: var(--tap);
+  padding: 12px 14px;
+  border-radius: 18px;
+  background: rgba(255, 253, 245, .1);
+  text-align: left;
+  transition: background .15s ease, transform .1s ease;
+}
+.choice-row:active { transform: translateY(2px); }
+.choice-row.selected { background: rgba(126, 217, 87, .18); box-shadow: inset 0 0 0 2px rgba(126, 217, 87, .55); }
+
+.choice-emoji { flex: 0 0 auto; font-size: 1.8rem; line-height: 1; }
+.choice-text { flex: 1 1 auto; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.choice-text strong { font-size: 1.05rem; color: var(--cream); }
+.choice-text span { font-size: .8rem; font-weight: 600; color: var(--mist); line-height: 1.35; }
+.choice-mark { flex: 0 0 22px; font-size: 1.4rem; font-weight: 800; color: var(--lime); text-align: center; }
+
+/* A switch rather than a tick: these four are on-or-off, not one-of-three. */
+.choice-switch {
+  flex: 0 0 auto;
+  position: relative;
+  width: 52px; height: 30px;
+  border-radius: 999px;
+  background: rgba(255, 253, 245, .2);
+  transition: background .2s ease;
+}
+.choice-switch::after {
+  content: '';
+  position: absolute;
+  top: 3px; left: 3px;
+  width: 24px; height: 24px;
+  border-radius: 50%;
+  background: var(--cream);
+  transition: transform .2s ease;
+}
+.choice-switch.on { background: var(--lime); }
+.choice-switch.on::after { transform: translateX(22px); }
+
 /* ---- map screen ----------------------------------------------------------- */
 
 .map-header {
@@ -294,6 +391,23 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
 @keyframes cheer {
   0% { transform: none; } 25% { transform: translateY(-14px) rotate(-8deg); }
   55% { transform: translateY(0) rotate(6deg); } 100% { transform: none; }
+}
+
+/* Three sizes of feeling. A right answer gets a hop, a streak gets the cheer
+   above, and a wrong one gets a small shake of the head — never a slump, since
+   the cub is on his side even when the sum is not. */
+.cub-happy { animation: happy .7s ease-out; }
+@keyframes happy {
+  0% { transform: none; } 35% { transform: translateY(-9px) scale(1.05); }
+  70% { transform: translateY(0) scale(.98); } 100% { transform: none; }
+}
+
+.cub-sad { animation: sad .6s ease-in-out; }
+@keyframes sad {
+  0%, 100% { transform: none; }
+  20% { transform: translateX(-7px) rotate(-3deg); }
+  50% { transform: translateX(6px) rotate(3deg); }
+  80% { transform: translateX(-3px) rotate(-1deg); }
 }
 
 /* ---- save the puppy (a frame, not a game) ---------------------------------- */
@@ -712,7 +826,8 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
 
 .clear-friend { font-size: 4.6rem; line-height: 1; animation: bob 2s ease-in-out infinite; }
 .clear-stars { font-size: 2.2rem; letter-spacing: 4px; margin-top: 6px; }
-.clear-note { margin: 10px 0 20px; font-size: 1.05rem; color: var(--mist); }
+.clear-note { margin: 10px 0 12px; font-size: 1.05rem; color: var(--mist); }
+.clear-score { margin: 0 0 20px; font-size: 1.1rem; font-weight: 800; color: var(--banana); }
 
 .region-cub { height: 150px; display: flex; justify-content: center; margin: 6px 0; }
 .region-cub .character-svg { height: 100%; width: auto; animation: cheer 1.4s ease-out; }
@@ -834,6 +949,11 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
 .card-name { margin: 0; font-size: 1rem; font-weight: 700; color: var(--cream); }
 .card-next { margin: 0; font-size: .84rem; font-weight: 600; color: var(--mist); line-height: 1.3; }
 
+/* The two things the card can do rather than show. */
+.card-actions { display: flex; flex-direction: column; gap: 10px; }
+.card-actions .big-button { font-size: 1.15rem; padding: 14px 24px; }
+.card-actions .ghost-button { font-size: .98rem; }
+
 /* One bar, the whole map. The single clearest answer to "how far am I?" */
 .profile-bar {
   position: relative;
@@ -915,6 +1035,13 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
   z-index: 30;
 }
 .mute { right: calc(10px + env(safe-area-inset-right)); }
+/* Under the mute rather than beside it: a third button in the row would run
+   into the level bar's pips, and the two audio switches belong together. */
+.music {
+  right: calc(10px + env(safe-area-inset-right));
+  top: calc(68px + env(safe-area-inset-top));
+}
+.music.off { opacity: .45; }
 .leaf { right: calc(70px + env(safe-area-inset-right)); opacity: .5; }
 .leaf.holding { animation: hold-fill 2s linear; }
 @keyframes hold-fill {
@@ -959,6 +1086,25 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
 /* Stars fly the same path as leaves, just further and slower. Must come after
    .leaf-bit — same specificity, so order decides the duration. */
 .star-bit { font-size: 1.7rem; animation-duration: 1.2s; }
+
+/* "+18 Lightning fast" lifting off the cub. Anchored in page pixels, so every
+   frame keeps the -50% that centres it on the thing it is about. */
+.float-label {
+  position: absolute;
+  z-index: 70;
+  pointer-events: none;
+  font-size: 1.3rem;
+  font-weight: 800;
+  white-space: nowrap;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, .35);
+  animation: float-off 1.1s ease-out forwards;
+}
+.float-score { color: var(--banana); }
+@keyframes float-off {
+  0%   { transform: translate(-50%, 0) scale(.7); opacity: 0; }
+  22%  { transform: translate(-50%, -10px) scale(1.1); opacity: 1; }
+  100% { transform: translate(-50%, -70px) scale(1); opacity: 0; }
+}
 
 /* A whole-screen wash of light. The biggest wins get one before the confetti,
    so the moment lands before the detail arrives. */

--- a/projects/jungle-addition/index.html
+++ b/projects/jungle-addition/index.html
@@ -61,6 +61,10 @@
     <a class="start-home" href="https://ranjithkumarshetty.github.io/">Made by Ranjith Kumar Shetty</a>
   </section>
 
+  <section id="screen-setup" class="screen">
+    <main id="setup-body" class="setup-body"></main>
+  </section>
+
   <section id="screen-map" class="screen">
     <header class="map-header">
       <button id="btn-profile" class="profile-chip" type="button"
@@ -113,10 +117,13 @@
       <div id="clear-friend" class="clear-friend">🦜</div>
       <div id="clear-stars" class="clear-stars">⭐⭐⭐</div>
       <p id="clear-note" class="clear-note">A new friend joined your parade!</p>
+      <p id="clear-score" class="clear-score">🏅 0 points</p>
       <div class="overlay-buttons">
         <button id="btn-clear-next" class="big-button" type="button">Next stop →</button>
+        <button id="btn-clear-share" class="ghost-button" type="button">Share this stop 📣</button>
         <button id="btn-clear-map" class="ghost-button" type="button">Back to the map</button>
       </div>
+      <p id="clear-share-note" class="save-note" role="status" aria-live="polite"></p>
     </div>
   </div>
 
@@ -158,6 +165,7 @@
   <!-- Persistent chrome and effect layers --------------------------------- -->
 
   <button id="btn-mute" class="corner-button mute" type="button" aria-label="Turn sound off">🔊</button>
+  <button id="btn-music" class="corner-button music" type="button" aria-label="Turn music off">🎵</button>
   <button id="grownup-leaf" class="corner-button leaf" type="button"
           aria-label="Grown-up corner — press and hold">🍃</button>
 
@@ -169,6 +177,8 @@
   <!-- Load order matters: plain scripts, no modules, so file:// just works. -->
   <script src="js/facts.js"></script>
   <script src="js/progress.js"></script>
+  <script src="js/score.js"></script>
+  <script src="js/share.js"></script>
   <script src="js/audio.js"></script>
   <script src="js/character.js"></script>
   <script src="js/celebrate.js"></script>
@@ -180,6 +190,7 @@
   <script src="js/games.js"></script>
   <script src="js/map.js"></script>
   <script src="js/profile.js"></script>
+  <script src="js/setup.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/projects/jungle-addition/js/audio.js
+++ b/projects/jungle-addition/js/audio.js
@@ -24,6 +24,7 @@ window.Sound = (function () {
       ctx = null;
     }
     pickVoice();
+    startMusic();
   }
 
   function pickVoice() {
@@ -50,8 +51,10 @@ window.Sound = (function () {
 
   /* ---- sound effects ----------------------------------------------------- */
 
-  function tone(freq, startOffset, duration, type, peak) {
-    if (!ctx || muted) return;
+  /* The raw voice. Music and effects have separate switches, so the mute check
+     lives one layer up in tone() rather than down here. */
+  function emit(freq, startOffset, duration, type, peak) {
+    if (!ctx) return;
     try {
       const start = ctx.currentTime + startOffset;
       const osc = ctx.createOscillator();
@@ -69,6 +72,11 @@ window.Sound = (function () {
     } catch (err) {
       /* An exhausted or closed AudioContext should never break gameplay. */
     }
+  }
+
+  function tone(freq, startOffset, duration, type, peak) {
+    if (muted) return;
+    emit(freq, startOffset, duration, type, peak);
   }
 
   function correct() {
@@ -92,6 +100,87 @@ window.Sound = (function () {
     [523, 659, 784, 1047, 1319].forEach((freq, i) => tone(freq, i * 0.1, 0.5, 'sine', 0.18));
     tone(392, 0.55, 0.9, 'triangle', 0.14);
   }
+
+  /* ---- music -------------------------------------------------------------- */
+
+  /* A loop, not a song: a few pentatonic notes over a walking bass, quiet enough
+     to sit under speech. Two moods so the rescue stops feel like a chase, and
+     nothing to download — the whole soundtrack is this table. */
+  const MOODS = {
+    jungle: {
+      stepMs: 250,
+      noteMs: 0.22,
+      melody: [523, 659, 784, 659, 587, 784, 880, 784,
+               523, 659, 784, 1047, 880, 784, 659, 587],
+      bass: [131, 131, 175, 196]
+    },
+    chase: {
+      stepMs: 170,
+      noteMs: 0.15,
+      melody: [587, 698, 880, 698, 622, 740, 932, 740],
+      bass: [147, 147, 156, 175]
+    }
+  };
+
+  const MUSIC_PEAK = 0.045;
+
+  let musicOn = true;
+  let musicTimer = null;
+  let musicStep = 0;
+  let mood = 'jungle';
+
+  function setMusicOn(value) {
+    musicOn = !!value;
+    if (musicOn) startMusic(); else stopMusic();
+    return musicOn;
+  }
+
+  function isMusicOn() { return musicOn; }
+
+  /* Switching mood restarts the loop from the top so the new tempo lands on a
+     beat rather than halfway through the old one. */
+  function setMood(name) {
+    const next = MOODS[name] ? name : 'jungle';
+    if (next === mood) return mood;
+
+    mood = next;
+    musicStep = 0;
+    if (musicTimer) {
+      stopMusic();
+      startMusic();
+    }
+    return mood;
+  }
+
+  function startMusic() {
+    if (muted || !musicOn || !ctx || musicTimer) return;
+    stepMusic();
+    musicTimer = setInterval(stepMusic, MOODS[mood].stepMs);
+  }
+
+  function stopMusic() {
+    if (musicTimer) clearInterval(musicTimer);
+    musicTimer = null;
+  }
+
+  function stepMusic() {
+    const tune = MOODS[mood];
+    emit(tune.melody[musicStep % tune.melody.length], 0, tune.noteMs, 'triangle', MUSIC_PEAK);
+
+    if (musicStep % 4 === 0) {
+      const bass = tune.bass[(musicStep / 4) % tune.bass.length];
+      emit(bass, 0, (tune.stepMs * 3) / 1000, 'sine', MUSIC_PEAK * 0.9);
+    }
+    musicStep += 1;
+  }
+
+  /* A tune playing on in a backgrounded tab is the fastest way to get a game
+     deleted, and timers there are throttled into a stutter anyway. */
+  try {
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) stopMusic(); else startMusic();
+    });
+  } catch (err) { /* no document, no tab to hide */ }
 
   /* ---- speech ------------------------------------------------------------ */
 
@@ -138,6 +227,9 @@ window.Sound = (function () {
     if (muted && window.speechSynthesis) {
       try { window.speechSynthesis.cancel(); } catch (err) { /* ignore */ }
     }
+    /* The master switch really is master: 🔇 takes the tune with it, and
+       unmuting brings it back only if its own switch was left on. */
+    if (muted) stopMusic(); else startMusic();
     return muted;
   }
 
@@ -145,6 +237,7 @@ window.Sound = (function () {
 
   return {
     unlock, setMuted, isMuted,
+    setMusicOn, isMusicOn, setMood, startMusic, stopMusic,
     correct, wrong, pop, levelClear, regionClear,
     speak, speakProblem, praise, encourage
   };

--- a/projects/jungle-addition/js/celebrate.js
+++ b/projects/jungle-addition/js/celebrate.js
@@ -282,6 +282,20 @@ window.Celebrate = (function () {
     layer.appendChild(banner);
   }
 
+  /* A small label that lifts off an element and fades — "+12", "Nice!". Anchored
+     to the thing it is about, unlike bigText which owns the whole screen. */
+  function floatText(element, text, className) {
+    const layer = Celebrate.balloonLayer;
+    if (!layer || !element || !text) return;
+
+    const box = element.getBoundingClientRect();
+    const label = disposable('float-label' + (className ? ' ' + className : ''));
+    label.textContent = text;
+    label.style.left = (box.left + box.width / 2) + 'px';
+    label.style.top = (box.top + box.height / 4) + 'px';
+    layer.appendChild(label);
+  }
+
   /* Every screen effect is a one-shot div that sweeps itself up. */
   function disposable(className) {
     const node = document.createElement('div');
@@ -308,6 +322,6 @@ window.Celebrate = (function () {
     init, pulse, clearConfetti, clearAll, reducedMotion,
     confetti, fireworks, balloons,
     leafPuff, starBurst,
-    flash, emojiRain, bigText
+    flash, emojiRain, bigText, floatText
   };
 })();

--- a/projects/jungle-addition/js/character.js
+++ b/projects/jungle-addition/js/character.js
@@ -1,7 +1,45 @@
-/* character.js — the tiger cub and his friend parade, drawn as inline SVG.
-   Upgrades are additive layers so growth is a data change, not a redraw. */
+/* character.js — the cub and his friend parade, drawn as inline SVG.
+   Upgrades are additive layers so growth is a data change, not a redraw, and
+   the cub himself is one rig in five coats: picking an avatar swaps a palette
+   and two shapes, never the drawing. */
 window.Character = (function () {
   'use strict';
+
+  /* Same rig, different animal. `ear` and `marks` name a shape; everything
+     else is colour. Adding a sixth cub is one row here. */
+  const AVATARS = [
+    { id: 'tiger',   name: 'Tiger',   emoji: '🐯', ear: 'round',   marks: 'stripes',
+      fur: '#f59b3c', dark: '#e8892b', face: '#f9ad52', belly: '#ffe2bd',
+      muzzle: '#fff3e0', inner: '#ffb9b0', mark: '#4a2c14', nose: '#c9524a' },
+    { id: 'panda',   name: 'Panda',   emoji: '🐼', ear: 'round',   marks: 'patches',
+      fur: '#f7f5ef', dark: '#ded9d0', face: '#fffdf8', belly: '#ffffff',
+      muzzle: '#ffffff', inner: '#6f6a66', mark: '#2f2b28', nose: '#2f2b28',
+      earFill: '#2f2b28' },
+    { id: 'fox',     name: 'Fox',     emoji: '🦊', ear: 'pointed', marks: 'none',
+      fur: '#ef7a45', dark: '#d95f2e', face: '#f58b58', belly: '#ffe9d6',
+      muzzle: '#fff6ec', inner: '#ffc4ae', mark: '#6b3218', nose: '#43261a' },
+    { id: 'koala',   name: 'Koala',   emoji: '🐨', ear: 'fluffy',  marks: 'none',
+      fur: '#9fb0bb', dark: '#86969f', face: '#a9bac5', belly: '#e6edf1',
+      muzzle: '#f2f6f8', inner: '#cfd8de', mark: '#44515a', nose: '#3b464e' },
+    { id: 'leopard', name: 'Leopard', emoji: '🐆', ear: 'round',   marks: 'spots',
+      fur: '#f2c14e', dark: '#d9a838', face: '#f6cc63', belly: '#fff0c9',
+      muzzle: '#fff8e4', inner: '#ffd9a8', mark: '#4a3312', nose: '#8a4a2a' }
+  ];
+
+  let avatarId = AVATARS[0].id;
+
+  function setAvatar(id) {
+    avatarId = AVATARS.some(a => a.id === id) ? id : AVATARS[0].id;
+    return avatarId;
+  }
+
+  function getAvatar() { return avatarId; }
+
+  function avatarInfo(id) {
+    return AVATARS.find(a => a.id === (id || avatarId)) || AVATARS[0];
+  }
+
+  function palette() { return avatarInfo(avatarId); }
 
   /* One friend per stop cleared, in the order they join the parade. Positions
      16 and 20 are the two rescue stops, so the puppy and the guide dog land on
@@ -42,42 +80,92 @@ window.Character = (function () {
   }
 
   function tail() {
+    const p = palette();
     return `<path class="cub-tail" d="M72 78 q16 2 14 -12 q-1 -8 -8 -7"
-              fill="none" stroke="#e8892b" stroke-width="6" stroke-linecap="round"/>`;
+              fill="none" stroke="${p.dark}" stroke-width="6" stroke-linecap="round"/>`;
   }
 
   function body() {
+    const p = palette();
     return `
-      <ellipse cx="50" cy="74" rx="21" ry="18" fill="#f59b3c"/>
-      <ellipse cx="50" cy="79" rx="12" ry="11" fill="#ffe2bd"/>
-      <ellipse cx="34" cy="89" rx="7" ry="5" fill="#e8892b"/>
-      <ellipse cx="66" cy="89" rx="7" ry="5" fill="#e8892b"/>`;
+      <ellipse cx="50" cy="74" rx="21" ry="18" fill="${p.fur}"/>
+      <ellipse cx="50" cy="79" rx="12" ry="11" fill="${p.belly}"/>
+      <ellipse cx="34" cy="89" rx="7" ry="5" fill="${p.dark}"/>
+      <ellipse cx="66" cy="89" rx="7" ry="5" fill="${p.dark}"/>`;
   }
 
   function head() {
+    const p = palette();
     return `
       <g class="cub-head">
-        <circle cx="33" cy="26" r="8.5" fill="#f59b3c"/>
-        <circle cx="67" cy="26" r="8.5" fill="#f59b3c"/>
-        <circle cx="33" cy="26" r="4"   fill="#ffb9b0"/>
-        <circle cx="67" cy="26" r="4"   fill="#ffb9b0"/>
+        ${ears(p)}
 
-        <circle cx="50" cy="38" r="24" fill="#f9ad52"/>
+        <circle cx="50" cy="38" r="24" fill="${p.face}"/>
 
-        <path d="M38 20 q3 6 1 11" stroke="#4a2c14" stroke-width="3" fill="none" stroke-linecap="round"/>
-        <path d="M50 17 q0 6 0 10"  stroke="#4a2c14" stroke-width="3" fill="none" stroke-linecap="round"/>
-        <path d="M62 20 q-3 6 -1 11" stroke="#4a2c14" stroke-width="3" fill="none" stroke-linecap="round"/>
+        ${marks(p)}
 
-        <ellipse cx="50" cy="46" rx="13" ry="10" fill="#fff3e0"/>
-        <circle class="cub-eye" cx="41" cy="36" r="4.2" fill="#3a2411"/>
-        <circle class="cub-eye" cx="59" cy="36" r="4.2" fill="#3a2411"/>
+        <ellipse cx="50" cy="46" rx="13" ry="10" fill="${p.muzzle}"/>
+        <circle class="cub-eye" cx="41" cy="36" r="4.2" fill="${p.mark}"/>
+        <circle class="cub-eye" cx="59" cy="36" r="4.2" fill="${p.mark}"/>
         <circle cx="42.4" cy="34.6" r="1.5" fill="#fff"/>
         <circle cx="60.4" cy="34.6" r="1.5" fill="#fff"/>
 
-        <path d="M46 43.5 h8 l-4 4 z" fill="#c9524a"/>
+        <path d="M46 43.5 h8 l-4 4 z" fill="${p.nose}"/>
         <path class="cub-mouth" d="M50 48 q-5 5 -9 1 M50 48 q5 5 9 1"
-              stroke="#8a4a2a" stroke-width="2.2" fill="none" stroke-linecap="round"/>
+              stroke="${p.mark}" stroke-width="2.2" fill="none" stroke-linecap="round"/>
       </g>`;
+  }
+
+  /* Ears and markings are the only shape that changes between avatars, so each
+     is one small dispatcher rather than five copies of the whole head. */
+  function ears(p) {
+    const outer = p.earFill || p.fur;
+    if (p.ear === 'pointed') {
+      return `
+        <path d="M26 32 L30 10 L45 24 Z" fill="${outer}"/>
+        <path d="M74 32 L70 10 L55 24 Z" fill="${outer}"/>
+        <path d="M31 28 L33 18 L40 25 Z" fill="${p.inner}"/>
+        <path d="M69 28 L67 18 L60 25 Z" fill="${p.inner}"/>`;
+    }
+    if (p.ear === 'fluffy') {
+      return `
+        <circle cx="28" cy="27" r="12" fill="${outer}"/>
+        <circle cx="72" cy="27" r="12" fill="${outer}"/>
+        <circle cx="28" cy="27" r="7"  fill="${p.inner}"/>
+        <circle cx="72" cy="27" r="7"  fill="${p.inner}"/>`;
+    }
+    return `
+      <circle cx="33" cy="26" r="8.5" fill="${outer}"/>
+      <circle cx="67" cy="26" r="8.5" fill="${outer}"/>
+      <circle cx="33" cy="26" r="4"   fill="${p.inner}"/>
+      <circle cx="67" cy="26" r="4"   fill="${p.inner}"/>`;
+  }
+
+  function marks(p) {
+    if (p.marks === 'spots') {
+      return `
+        <circle cx="36" cy="26" r="2.6" fill="${p.mark}" opacity=".55"/>
+        <circle cx="50" cy="22" r="2.2" fill="${p.mark}" opacity=".55"/>
+        <circle cx="64" cy="26" r="2.6" fill="${p.mark}" opacity=".55"/>
+        <circle cx="31" cy="40" r="2.4" fill="${p.mark}" opacity=".45"/>
+        <circle cx="69" cy="40" r="2.4" fill="${p.mark}" opacity=".45"/>`;
+    }
+    /* The white discs keep the eyes readable: they are drawn in the mark colour
+       further down, which on a panda is the patch colour too. */
+    if (p.marks === 'patches') {
+      return `
+        <ellipse cx="41" cy="36" rx="8" ry="9" fill="${p.mark}" transform="rotate(-14 41 36)"/>
+        <ellipse cx="59" cy="36" rx="8" ry="9" fill="${p.mark}" transform="rotate(14 59 36)"/>
+        <circle cx="41" cy="36" r="5" fill="#fff"/>
+        <circle cx="59" cy="36" r="5" fill="#fff"/>`;
+    }
+    if (p.marks === 'stripes') {
+      return `
+        <path d="M38 20 q3 6 1 11" stroke="${p.mark}" stroke-width="3" fill="none" stroke-linecap="round"/>
+        <path d="M50 17 q0 6 0 10"  stroke="${p.mark}" stroke-width="3" fill="none" stroke-linecap="round"/>
+        <path d="M62 20 q-3 6 -1 11" stroke="${p.mark}" stroke-width="3" fill="none" stroke-linecap="round"/>`;
+    }
+    return '';
   }
 
   function hat() {
@@ -145,6 +233,27 @@ window.Character = (function () {
       `<svg class="character-svg" viewBox="0 0 100 100" aria-hidden="true">${markup(stage)}</svg>`;
   }
 
+  /* Draw any avatar without disturbing the chosen one — the picker needs all
+     five at once, and every drawing function reads the module's current pick. */
+  function markupFor(id, stage) {
+    const previous = avatarId;
+    avatarId = avatarInfo(id).id;
+    const svg = markup(stage);
+    avatarId = previous;
+    return svg;
+  }
+
+  /* The picker shows the real rig rather than an emoji stand-in, so the child
+     chooses the cub they will actually play as. */
+  function renderChoices(host, selectedId) {
+    host.innerHTML = AVATARS.map(a => `
+      <button class="avatar-option${a.id === selectedId ? ' selected' : ''}" type="button"
+              data-avatar="${a.id}" aria-pressed="${a.id === selectedId}">
+        <svg class="avatar-svg" viewBox="0 0 100 100" aria-hidden="true">${markupFor(a.id, 0)}</svg>
+        <span class="avatar-name">${a.name}</span>
+      </button>`).join('');
+  }
+
   /* The conga line of friends earned so far — the always-visible trophy case. */
   function renderParade(host, friendCount) {
     const count = Math.max(0, Math.min(FRIENDS.length, friendCount || 0));
@@ -171,5 +280,20 @@ window.Character = (function () {
     return FRIENDS[index % FRIENDS.length];
   }
 
-  return { FRIENDS, STAGES, stageInfo, markup, render, renderParade, renderCollection, friendAt };
+  return {
+    FRIENDS,
+    STAGES,
+    AVATARS,
+    stageInfo,
+    setAvatar,
+    getAvatar,
+    avatarInfo,
+    markup,
+    markupFor,
+    render,
+    renderChoices,
+    renderParade,
+    renderCollection,
+    friendAt
+  };
 })();

--- a/projects/jungle-addition/js/facts.js
+++ b/projects/jungle-addition/js/facts.js
@@ -7,8 +7,14 @@ window.Facts = (function () {
   const QUESTIONS_PER_STOP = 6;
   const MAX_OPTION = 25;
 
-  /* Distractors are near-misses in priority order, so guessing doesn't pay. */
+  /* Distractors are near-misses in priority order, so guessing doesn't pay.
+     Easy pushes the wrong answers further away, hard crowds them in. */
   const DISTRACTOR_OFFSETS = [1, -1, 2, -2, 3, -3, 10, -10];
+  const GENTLE_OFFSETS = [2, -2, 3, -3, 5, -5, 10, -10];
+  const TIGHT_OFFSETS = [1, -1, 2, -2, 3, -3];
+
+  const DIFFICULTIES = ['easy', 'medium', 'hard'];
+  let difficulty = 'medium';
 
   const REGIONS = [
     { id: 0, name: 'Riverbank',      emoji: '🌊',  stops: [1, 2, 3, 4] },
@@ -80,21 +86,23 @@ window.Facts = (function () {
     { id: 8,  region: 1, game: 'match',    title: 'Firefly Hollow',    min: 6,  max: 15, build: () => sumsBetween(6, 15) },
     { id: 9,  region: 2, game: 'quick',    title: 'Cloud Ridge',       min: 11, max: 20, build: () => sumsBetween(11, 20) },
     { id: 10, region: 2, game: 'missing',  title: 'Echo Caves',        min: 11, max: 20, build: () => sumsBetween(11, 20) },
-    { id: 11, region: 2, game: 'quick',    title: 'Three Peaks',       min: 10, max: 20, build: () => threeAddends(10, 20) },
+    { id: 11, region: 2, game: 'quick',    title: 'Three Peaks',       min: 10, max: 20, build: () => threeAddends(10, 20), easyBuild: () => sumsBetween(10, 20) },
     { id: 12, region: 2, game: 'match',    title: 'Summit Temple',     min: 10, max: 20, build: () => sumsBetween(10, 20) },
 
     /* Regions 3 and 4 hold the math ceiling steady and raise difficulty
        structurally instead: tighter distractors, three addends, compound
        equality. `pick`/`stones`/`tight`/`compound` are read by the mechanic
-       that owns the stop; `frame` is dramatic dressing over any of them. */
+       that owns the stop; `frame` is dramatic dressing over any of them.
+       `easyBuild` is the two-addend pool Easy swaps in — same numbers to
+       learn, one fewer thing to hold in your head at once. */
     { id: 13, region: 3, game: 'build',   title: 'Fruit Vault',    min: 8,  max: 15, pick: 2, build: () => sumsBetween(8, 15) },
     { id: 14, region: 3, game: 'route',   title: 'Treasure Trail', min: 8,  max: 15, stones: 3, build: () => sumsBetween(8, 15) },
     { id: 15, region: 3, game: 'balance', title: 'Stone Scales',   min: 10, max: 18, build: () => sumsBetween(10, 18) },
     { id: 16, region: 3, game: 'route',   title: 'Idol Chamber',   min: 10, max: 20, stones: 3, frame: 'rescue', build: () => sumsBetween(10, 20) },
-    { id: 17, region: 4, game: 'build',   title: 'Sky Orchard',    min: 12, max: 20, pick: 3, build: () => threeAddends(12, 20) },
+    { id: 17, region: 4, game: 'build',   title: 'Sky Orchard',    min: 12, max: 20, pick: 3, build: () => threeAddends(12, 20), easyBuild: () => sumsBetween(12, 20) },
     { id: 18, region: 4, game: 'balance', title: 'Twin Scales',    min: 12, max: 20, compound: true, build: () => sumsBetween(12, 20) },
     { id: 19, region: 4, game: 'route',   title: 'Cliff Crossing', min: 12, max: 20, stones: 3, tight: true, build: () => sumsBetween(12, 20) },
-    { id: 20, region: 4, game: 'build',   title: 'Storm Summit',   min: 12, max: 20, pick: 3, tight: true, frame: 'rescue', build: () => threeAddends(12, 20) }
+    { id: 20, region: 4, game: 'build',   title: 'Storm Summit',   min: 12, max: 20, pick: 3, tight: true, frame: 'rescue', build: () => threeAddends(12, 20), easyBuild: () => sumsBetween(12, 20) }
   ];
 
   /* Every distinct game type, in roster order — the All-Rounder badge and the
@@ -103,17 +111,65 @@ window.Facts = (function () {
     return STOPS.map(s => s.game).filter((g, i, all) => all.indexOf(g) === i);
   }
 
+  /* ---- difficulty --------------------------------------------------------
+     One dial over the roster rather than three rosters. Every mechanic already
+     reads its shape off the stop it is handed, so bending the config here bends
+     the whole game and no mechanic learns a new word. The raw STOPS table stays
+     untouched — the map still draws the same trail at every level. */
+
+  function setDifficulty(level) {
+    difficulty = DIFFICULTIES.includes(level) ? level : 'medium';
+    return difficulty;
+  }
+
+  function getDifficulty() { return difficulty; }
+
+  /* Easy: two addends everywhere, two stones at a fork, no compound scales and
+     wrong answers that sit visibly apart. Hard: near-miss distractors on every
+     stop, not just the last two. */
+  function tuned(config) {
+    if (difficulty === 'hard') return Object.assign({}, config, { tight: true });
+    if (difficulty !== 'easy') return config;
+    return Object.assign({}, config, {
+      pick: 2,
+      stones: 2,
+      tight: false,
+      compound: false,
+      build: config.easyBuild || config.build
+    });
+  }
+
+  function offsetsFor(spread) {
+    if (spread === 'gentle') return GENTLE_OFFSETS;
+    if (spread === 'tight') return TIGHT_OFFSETS;
+    if (spread === 'normal') return DISTRACTOR_OFFSETS;
+    if (difficulty === 'easy') return GENTLE_OFFSETS;
+    if (difficulty === 'hard') return TIGHT_OFFSETS;
+    return DISTRACTOR_OFFSETS;
+  }
+
+  /* Answers over ten, three addends and the structural stops are the ones worth
+     a bonus — the same judgement the roster already makes, read back out. */
+  function isHardProblem(problem, config) {
+    return problem.answer > 10
+        || problem.addends.length > 2
+        || !!(config && (config.tight || config.compound));
+  }
+
   const poolCache = {};
 
   function stop(id) {
     const found = STOPS.find(s => s.id === id);
     if (!found) throw new Error('unknown stop ' + id);
-    return found;
+    return tuned(found);
   }
 
+  /* Keyed by difficulty too: Easy hands back a different pool for the
+     three-addend stops, and a stale cache would serve the wrong one. */
   function poolForStop(id) {
-    if (!poolCache[id]) poolCache[id] = stop(id).build();
-    return poolCache[id];
+    const key = difficulty + ':' + id;
+    if (!poolCache[key]) poolCache[key] = stop(id).build();
+    return poolCache[key];
   }
 
   function regionOf(stopId) {
@@ -193,11 +249,12 @@ window.Facts = (function () {
 
   /* ---- answer options ---------------------------------------------------- */
 
-  function buildOptions(answer, rng) {
+  /* `spread` overrides the difficulty default — 'gentle', 'normal' or 'tight'. */
+  function buildOptions(answer, rng, spread) {
     rng = rng || Math.random;
     const options = [answer];
 
-    for (const offset of DISTRACTOR_OFFSETS) {
+    for (const offset of offsetsFor(spread)) {
       if (options.length === 4) break;
       const candidate = answer + offset;
       if (candidate < 0 || candidate > MAX_OPTION) continue;
@@ -238,6 +295,7 @@ window.Facts = (function () {
 
   return {
     QUESTIONS_PER_STOP,
+    DIFFICULTIES,
     REGIONS,
     STOPS,
     stop,
@@ -247,6 +305,9 @@ window.Facts = (function () {
     gameTypes,
     decompose,
     buildOptions,
-    generateStop
+    generateStop,
+    setDifficulty,
+    getDifficulty,
+    isHardProblem
   };
 })();

--- a/projects/jungle-addition/js/main.js
+++ b/projects/jungle-addition/js/main.js
@@ -9,6 +9,7 @@ window.Main = (function () {
 
   const el = {};
   let level = null;          // the level in progress, or null on the map
+  let lastRun = null;        // the stop just cleared, kept for the share button
 
   /* ---- boot ---------------------------------------------------------------- */
 
@@ -27,6 +28,7 @@ window.Main = (function () {
       Celebrate.init(el.confetti, el.balloons);
       Sound.setMuted(Progress.get().muted);
       syncMuteButton();
+      applySettings();
       el.startButton.textContent =
         Progress.get().clearedStops.length ? 'Keep exploring 🌿' : 'Start the adventure 🌿';
     } catch (err) {
@@ -43,6 +45,8 @@ window.Main = (function () {
       start: byId('screen-start'),
       map: byId('screen-map'),
       levelScreen: byId('screen-level'),
+
+      setupBody: byId('setup-body'),
 
       startButton: byId('btn-start'),
       trail: byId('trail'),
@@ -69,6 +73,9 @@ window.Main = (function () {
       clearFriend: byId('clear-friend'),
       clearStars: byId('clear-stars'),
       clearNote: byId('clear-note'),
+      clearScore: byId('clear-score'),
+      clearShare: byId('btn-clear-share'),
+      clearShareNote: byId('clear-share-note'),
       clearNext: byId('btn-clear-next'),
       clearMap: byId('btn-clear-map'),
 
@@ -88,6 +95,7 @@ window.Main = (function () {
       grownupSaveNote: byId('grownup-save-note'),
 
       muteButton: byId('btn-mute'),
+      musicButton: byId('btn-music'),
       grownupLeaf: byId('grownup-leaf'),
       confetti: byId('confetti'),
       balloons: byId('balloons')
@@ -95,14 +103,19 @@ window.Main = (function () {
   }
 
   function wireChrome() {
+    /* The first tap is the only chance to start audio, so it also decides
+       whether the child goes to the wizard or straight back to the trail. */
     el.startButton.addEventListener('click', () => {
       Sound.unlock();
+      if (!Progress.settings().done) return openSetup();
       Sound.speak('Welcome back, explorer!');
       openMap();
     });
 
     el.backButton.addEventListener('click', leaveLevel);
     el.muteButton.addEventListener('click', toggleMute);
+    el.musicButton.addEventListener('click', toggleMusic);
+    el.clearShare.addEventListener('click', shareLevel);
 
     el.profileChip.addEventListener('click', openProfile);
     el.profileBack.addEventListener('click', () => openMap());
@@ -138,6 +151,7 @@ window.Main = (function () {
     level = null;
     Games.stop();
     Rescue.clear();
+    Sound.setMood('jungle');
     show('map');
     refreshMap(characterStop);
   }
@@ -165,9 +179,31 @@ window.Main = (function () {
   }
 
   function openProfile() {
-    Profile.render(el.profileBody);
+    Profile.render(el.profileBody, { onShare: shareAdventure, onSettings: openSetup });
     show('profile');
     Sound.speak(`You are a ${Character.stageInfo(Progress.get().stage).label}.`);
+  }
+
+  /* ---- setup ---------------------------------------------------------------- */
+
+  /* The three saved choices reach three different modules, so one place applies
+     them all — at boot, after the wizard, and after a restore. */
+  function applySettings() {
+    const settings = Progress.settings();
+    Facts.setDifficulty(settings.difficulty);
+    Character.setAvatar(settings.avatar);
+    Sound.setMusicOn(settings.music);
+    syncMusicButton();
+  }
+
+  function openSetup() {
+    Setup.open(el.setupBody, Progress.settings(), chosen => {
+      Progress.updateSettings(chosen);
+      applySettings();
+      Sound.speak("Great choice! Let's explore!");
+      openMap();
+    });
+    show('setup');
   }
 
   /* ---- playing a level ------------------------------------------------------ */
@@ -178,7 +214,18 @@ window.Main = (function () {
 
     const problems = Facts.generateStop(stopId, Progress.get().facts);
 
-    level = { stop, problems, streak: 0, correctFirstTry: 0 };
+    level = {
+      stop, problems,
+      streak: 0, correctFirstTry: 0,
+      rules: Score.rulesFrom(Progress.settings()),
+      startedAt: Date.now(),
+      askedAt: Date.now(),      // when the question on screen appeared
+      wrongs: 0,                // wrong tries on that question alone
+      points: 0
+    };
+
+    /* A rescue is a chase, so the tune becomes one. */
+    Sound.setMood(stop.frame === 'rescue' ? 'chase' : 'jungle');
 
     el.levelStop.textContent = `Stop ${stop.id}`;
     el.levelName.textContent = stop.title;
@@ -198,6 +245,7 @@ window.Main = (function () {
       problems,
       host: el.gameHost,
       hooks: {
+        onQuestionShown: handleQuestionShown,
         onCorrect: handleCorrect,
         onWrong: handleWrong,
         onQuestionDone: handleQuestionDone,
@@ -215,10 +263,20 @@ window.Main = (function () {
     el.pips.innerHTML = html;
   }
 
+  /* The clock for the speed bonus starts when the question lands on screen, not
+     when the level did, so the pause after the previous answer costs nothing. */
+  function handleQuestionShown() {
+    if (!level) return;
+    level.askedAt = Date.now();
+    level.wrongs = 0;
+  }
+
   function handleCorrect(problem, element, attempts) {
     if (!level) return;
     level.streak = attempts === 0 ? level.streak + 1 : 0;
     if (attempts === 0) level.correctFirstTry += 1;
+
+    Celebrate.pulse(el.levelCub, 'cub-happy', 700);
 
     if (level.streak > 0 && level.streak % STREAK_FOR_CHEER === 0) {
       Celebrate.confetti(30);
@@ -229,13 +287,39 @@ window.Main = (function () {
   }
 
   function handleWrong() {
-    if (level) level.streak = 0;
+    if (!level) return;
+    level.streak = 0;
+    level.wrongs += 1;
+    Celebrate.pulse(el.levelCub, 'cub-sad', 600);
   }
 
   function handleQuestionDone(problem, missedFirstTry, stepsDone) {
     Progress.recordAnswer(problem.key, missedFirstTry);
+    awardPoints(problem);
     renderPips(stepsDone);
     Rescue.advance(stepsDone);
+    if (level) level.askedAt = Date.now();      // match boards never re-announce
+  }
+
+  /* Points are scored here rather than on the answer itself, so a question that
+     ended in a reveal still pays something — the promise is that finishing is
+     always worth more than giving up. */
+  function awardPoints(problem) {
+    if (!level) return;
+    const earned = Score.forQuestion(problem, level.stop, {
+      attempts: level.wrongs + 1,
+      elapsedMs: Date.now() - level.askedAt
+    }, level.rules);
+
+    level.points += earned.points;
+    Progress.addScore(earned.points);
+    Celebrate.floatText(el.levelCub, floatLabel(earned), 'float-score');
+  }
+
+  /* "+18 Lightning fast" — the number, plus the one word that explains it. */
+  function floatLabel(earned) {
+    const extra = earned.parts.find(part => part.points > 0 && part.label !== 'Correct');
+    return `+${earned.points}${extra ? ' ' + extra.label : ''}`;
   }
 
   function leaveLevel() {
@@ -276,6 +360,13 @@ window.Main = (function () {
        easy stop would farm the perfect-stop badges. */
     if (perfect && outcome.isNew) Progress.recordPerfectStop();
 
+    const bonus = Score.stopBonus(perfect, finished.rules);
+    if (bonus) {
+      finished.points += bonus;
+      Progress.addScore(bonus);
+    }
+    Progress.save();
+
     Celebrate.flash();
     Celebrate.confetti(perfect ? 110 : 80);
     Celebrate.balloons(perfect ? 7 : 4);
@@ -300,7 +391,13 @@ window.Main = (function () {
     }
 
     el.clearStars.textContent = stars;
+    el.clearScore.textContent = `🏅 ${finished.points} points${bonus ? ' — perfect-stop bonus!' : ''}`;
     el.clearNext.hidden = Progress.currentStop() === finished.stop.id;
+
+    /* Held for the share button, which is tapped by a grown-up after the cub has
+       already run off to the next stop. */
+    lastRun = runSummary(finished, stars);
+    el.clearShareNote.textContent = '';
 
     Sound.speak(perfect ? 'Perfect! Every single one!' : 'Level complete! Great work!');
     open(el.overlayClear);
@@ -341,7 +438,56 @@ window.Main = (function () {
     open(el.overlayRegion);
   }
 
-  /* ---- mute and the grown-up corner ----------------------------------------- */
+  /* ---- sharing --------------------------------------------------------------- */
+
+  /* Everything Share needs about a finished stop, gathered while it is still in
+     memory — Progress keeps totals, not the story of one run. */
+  function runSummary(finished, stars) {
+    const avatar = Character.avatarInfo(Progress.settings().avatar);
+    return {
+      stopId: finished.stop.id,
+      stopName: finished.stop.title,
+      difficulty: Progress.settings().difficulty,
+      avatarName: avatar.name,
+      avatarEmoji: avatar.emoji,
+      solved: finished.problems.length,
+      mistakes: finished.problems.length - finished.correctFirstTry,
+      elapsedMs: Date.now() - finished.startedAt,
+      points: finished.points,
+      stars: stars
+    };
+  }
+
+  function shareLevel() {
+    if (!lastRun) return;
+    sendShare(Share.levelSummary(lastRun), el.clearShareNote);
+  }
+
+  function shareAdventure(note) {
+    const state = Progress.get();
+    const avatar = Character.avatarInfo(state.settings.avatar);
+    /* Share renders; it does not go looking. The rank and the avatar's name live
+       in Character, so they are folded in here rather than looked up there. */
+    const decorated = Object.assign({}, state, {
+      rank: Character.stageInfo(state.stage).label,
+      settings: Object.assign({}, state.settings,
+        { avatarName: avatar.name, avatarEmoji: avatar.emoji })
+    });
+    sendShare(Share.adventureSummary(decorated, Progress.stats(), Facts.STOPS.length), note);
+  }
+
+  function sendShare(text, note) {
+    Share.send(text).then(result => {
+      if (note) note.textContent = shareOutcome(result);
+    });
+  }
+
+  function shareOutcome(result) {
+    if (!result.ok) return result.how === 'cancelled' ? '' : 'Could not share from this browser.';
+    return result.how === 'shared' ? 'Shared! 📣' : 'Copied — paste it anywhere. 📋';
+  }
+
+  /* ---- mute, music and the grown-up corner ----------------------------------- */
 
   function toggleMute() {
     const muted = Sound.setMuted(!Sound.isMuted());
@@ -353,6 +499,21 @@ window.Main = (function () {
     const muted = Sound.isMuted();
     el.muteButton.textContent = muted ? '🔇' : '🔊';
     el.muteButton.setAttribute('aria-label', muted ? 'Turn sound on' : 'Turn sound off');
+  }
+
+  /* Music has its own switch: the tune is the first thing a grown-up wants gone,
+     and losing it should not take the spoken questions with it. */
+  function toggleMusic() {
+    const on = Sound.setMusicOn(!Sound.isMusicOn());
+    Progress.updateSettings({ music: on });
+    syncMusicButton();
+  }
+
+  function syncMusicButton() {
+    const on = Sound.isMusicOn();
+    el.musicButton.textContent = on ? '🎵' : '🎶';
+    el.musicButton.classList.toggle('off', !on);
+    el.musicButton.setAttribute('aria-label', on ? 'Turn music off' : 'Turn music on');
   }
 
   /* A two-second hold, so a curious five-year-old does not stumble in. */
@@ -423,6 +584,7 @@ window.Main = (function () {
       Badges.check();
       Sound.setMuted(Progress.get().muted);
       syncMuteButton();
+      applySettings();
       hide(el.overlayGrownup);
       openMap();
       saveNote('');
@@ -438,6 +600,7 @@ window.Main = (function () {
     Badges.clearAnnouncements(el.badgePop);
     Sound.setMuted(false);
     syncMuteButton();
+    applySettings();                    // back to the defaults, wizard and all
     hide(el.overlayGrownup);
     el.startButton.textContent = 'Start the adventure 🌿';
     show('start');

--- a/projects/jungle-addition/js/profile.js
+++ b/projects/jungle-addition/js/profile.js
@@ -9,11 +9,16 @@
 window.Profile = (function () {
   'use strict';
 
-  function render(host) {
+  /* `actions` are the two things the card can do rather than show — share the
+     adventure and reopen setup. Both optional, so the card still renders
+     read-only if a caller has nothing to wire up. */
+  function render(host, actions) {
     if (!host) return;
     const state = Progress.get();
     const stats = Progress.stats();
     const stage = Character.stageInfo(state.stage);
+    const settings = Progress.settings();
+    const avatar = Character.avatarInfo(settings.avatar);
     const totalStops = Facts.STOPS.length;
 
     host.innerHTML = `
@@ -21,9 +26,15 @@ window.Profile = (function () {
         <div class="card-cub" id="profile-cub"></div>
         <div class="card-titles">
           <p class="card-rank">${stage.label}</p>
-          <h3 class="card-name">Jungle Explorer</h3>
+          <h3 class="card-name">${avatar.name} the Explorer</h3>
           <p class="card-next">${nextRankLine(state)}</p>
         </div>
+      </div>
+
+      <div class="card-actions">
+        <button id="btn-share" class="big-button" type="button">Share my adventure 📣</button>
+        <button id="btn-settings" class="ghost-button" type="button">⚙️ Avatar, difficulty &amp; points</button>
+        <p id="share-note" class="save-note" role="status" aria-live="polite"></p>
       </div>
 
       <div class="profile-bar" role="img"
@@ -51,11 +62,23 @@ window.Profile = (function () {
         ${statTile('🧮', stats.answered, 'sums solved')}
         ${statTile('✅', stats.accuracy + '%', 'first-try right')}
         ${statTile('🎯', state.perfectStops, 'perfect stops')}
-      </div>`;
+        ${statTile('🏅', state.score, 'points')}
+      </div>
+      <p class="setup-note">Playing on ${settings.difficulty} · ${Score.describe(settings)}</p>`;
 
     Character.render(host.querySelector('#profile-cub'), state.stage);
     Character.renderCollection(host.querySelector('#profile-friends'), state.friends);
     Badges.renderGrid(host.querySelector('#profile-badges'));
+    wire(host, actions || {});
+  }
+
+  function wire(host, actions) {
+    const share = host.querySelector('#btn-share');
+    const settings = host.querySelector('#btn-settings');
+    if (actions.onShare) share.addEventListener('click', () => actions.onShare(host.querySelector('#share-note')));
+    else share.hidden = true;
+    if (actions.onSettings) settings.addEventListener('click', actions.onSettings);
+    else settings.hidden = true;
   }
 
   /* Rank comes from cleared regions, so the goal is always "finish the region

--- a/projects/jungle-addition/js/progress.js
+++ b/projects/jungle-addition/js/progress.js
@@ -21,7 +21,23 @@ window.Progress = (function () {
       muted: false,
       badges: [],        // earned badge ids, in the order they were earned
       perfectStops: 0,   // stops cleared without a single mistake
+      score: 0,          // lifetime points, only ever added to
+      settings: blankSettings(),
       facts: {}          // "7+8" -> { seen, missed }
+    };
+  }
+
+  /* Chosen once in the setup wizard and changeable from the explorer card.
+     Flat on purpose: one shape to default, decode and round-trip. */
+  function blankSettings() {
+    return {
+      done: false,          // has the child been through the wizard yet
+      avatar: 'tiger',
+      difficulty: 'medium',
+      music: true,
+      speed: false,         // faster answers score more — introduces a timer
+      mistakes: false,      // wrong answers cost points
+      bonus: true           // harder questions pay extra
     };
   }
 
@@ -71,9 +87,23 @@ window.Progress = (function () {
         ? parsed.badges.filter(id => typeof id === 'string') : fresh.badges,
       perfectStops: Number.isInteger(parsed.perfectStops)
         ? parsed.perfectStops : fresh.perfectStops,
+      score: Number.isInteger(parsed.score) ? parsed.score : fresh.score,
+      settings: decodeSettings(parsed.settings, fresh.settings),
       facts: (parsed.facts && typeof parsed.facts === 'object' && !Array.isArray(parsed.facts))
         ? parsed.facts : fresh.facts
     };
+  }
+
+  /* Key by key against the blank, so a save written before a setting existed —
+     or hand-edited afterwards — can only ever supply values the game knows, and
+     always in the same order the blank declares them. */
+  function decodeSettings(raw, fresh) {
+    const given = (raw && typeof raw === 'object' && !Array.isArray(raw)) ? raw : {};
+    const merged = {};
+    Object.keys(fresh).forEach(key => {
+      merged[key] = typeof given[key] === typeof fresh[key] ? given[key] : fresh[key];
+    });
+    return merged;
   }
 
   function load() {
@@ -219,6 +249,21 @@ window.Progress = (function () {
     return state.muted;
   }
 
+  function settings() { return state.settings; }
+
+  function updateSettings(patch) {
+    state.settings = decodeSettings(Object.assign({}, state.settings, patch), blankSettings());
+    save();
+    return state.settings;
+  }
+
+  /* Points only ever go up, and never below zero even if a rule takes some off.
+     Like recordAnswer, this leaves saving to the end of the level. */
+  function addScore(points) {
+    state.score = Math.max(0, state.score + (points || 0));
+    return state.score;
+  }
+
   return {
     KEY,
     load,
@@ -239,10 +284,14 @@ window.Progress = (function () {
     awardBadge,
     recordPerfectStop,
     setMuted,
+    settings,
+    updateSettings,
+    addScore,
 
     /* Test seam: swap the backend so tests never touch real progress. */
     __test: {
       blank,
+      blankSettings,
       decode,
       useStorage(fake) { storage = fake || realStorage(); }
     }

--- a/projects/jungle-addition/js/score.js
+++ b/projects/jungle-addition/js/score.js
@@ -1,0 +1,98 @@
+/* score.js — points for a question, as pure arithmetic.
+   Three optional rules, all off-by-default except the bonus, because the game's
+   promise is that trying again is free. Even with every rule switched on a
+   question can never score less than MIN_POINTS, and the running total never
+   goes down: scoring is a flourish on top of progress, never a punishment. */
+window.Score = (function () {
+  'use strict';
+
+  const BASE = 10;
+  const MIN_POINTS = 1;
+  const MISTAKE_COST = 4;
+
+  /* Answer inside this many seconds, take the bonus beside it. */
+  const SPEED_TIERS = [
+    { withinMs: 3000,  points: 8, label: 'Lightning fast' },
+    { withinMs: 6000,  points: 4, label: 'Quick thinking' },
+    { withinMs: 10000, points: 2, label: 'Good pace' }
+  ];
+
+  const BIG_ANSWER_BONUS = 3;
+  const THREE_ADDEND_BONUS = 3;
+  const TRICKY_STOP_BONUS = 2;
+  const PERFECT_STOP_BONUS = 25;
+
+  const DEFAULT_RULES = { speed: false, mistakes: false, bonus: true };
+
+  function rulesFrom(settings) {
+    const from = settings || {};
+    return {
+      speed: !!from.speed,
+      mistakes: !!from.mistakes,
+      bonus: from.bonus !== false
+    };
+  }
+
+  /* `outcome` is { attempts, elapsedMs } as the game recorded it: attempts counts
+     every try including the right one, elapsedMs is time on this question alone.
+     Returns the total and the parts that made it, so the popup can say why. */
+  function forQuestion(problem, config, outcome, rules) {
+    const active = rules || DEFAULT_RULES;
+    const tries = Math.max(1, (outcome && outcome.attempts) || 1);
+    const parts = [{ label: 'Correct', points: BASE }];
+
+    if (active.speed && tries === 1) {
+      const tier = speedTier((outcome && outcome.elapsedMs) || Infinity);
+      if (tier) parts.push({ label: tier.label, points: tier.points });
+    }
+
+    if (active.bonus) {
+      hardBonuses(problem, config).forEach(part => parts.push(part));
+    }
+
+    if (active.mistakes && tries > 1) {
+      parts.push({ label: 'Mistakes', points: -MISTAKE_COST * (tries - 1) });
+    }
+
+    const total = parts.reduce((sum, part) => sum + part.points, 0);
+    return { points: Math.max(MIN_POINTS, total), parts };
+  }
+
+  /* A clean sweep of a stop is the one thing worth a lump sum: it is the only
+     score the child can chase without being rushed or penalised. */
+  function stopBonus(perfect, rules) {
+    const active = rules || DEFAULT_RULES;
+    return (active.bonus && perfect) ? PERFECT_STOP_BONUS : 0;
+  }
+
+  /* One line for the share card and the settings summary. */
+  function describe(rules) {
+    const active = rules || DEFAULT_RULES;
+    const on = [];
+    if (active.speed) on.push('speed bonus');
+    if (active.mistakes) on.push('mistakes count');
+    if (active.bonus) on.push('hard-question bonus');
+    return on.length ? on.join(', ') : 'relaxed scoring';
+  }
+
+  function speedTier(elapsedMs) {
+    return SPEED_TIERS.find(tier => elapsedMs <= tier.withinMs) || null;
+  }
+
+  /* The roster already knows which questions are the hard ones — read that
+     judgement back out rather than inventing a second definition of hard. */
+  function hardBonuses(problem, config) {
+    const parts = [];
+    if (!problem) return parts;
+    if (problem.answer > 10) parts.push({ label: 'Big answer', points: BIG_ANSWER_BONUS });
+    if (problem.addends && problem.addends.length > 2) {
+      parts.push({ label: 'Three numbers', points: THREE_ADDEND_BONUS });
+    }
+    if (config && (config.tight || config.compound)) {
+      parts.push({ label: 'Tricky stop', points: TRICKY_STOP_BONUS });
+    }
+    return parts;
+  }
+
+  return { BASE, MIN_POINTS, DEFAULT_RULES, rulesFrom, forQuestion, stopBonus, describe };
+})();

--- a/projects/jungle-addition/js/setup.js
+++ b/projects/jungle-addition/js/setup.js
@@ -1,0 +1,137 @@
+/* setup.js — the three questions asked once, before the first stop.
+   Pick a cub, pick how tricky the sums are, pick whether points get clever.
+   Everything here edits a draft copy; nothing is saved until the last step, so
+   backing out of the wizard changes nothing. */
+window.Setup = (function () {
+  'use strict';
+
+  const LEVELS = [
+    { id: 'easy',   emoji: '🌱', name: 'Easy',   note: 'Two numbers to add, and the wrong answers sit further away' },
+    { id: 'medium', emoji: '🌿', name: 'Medium', note: 'The whole trail as it was built' },
+    { id: 'hard',   emoji: '🔥', name: 'Hard',   note: 'Three numbers and close answers — no guessing your way up' }
+  ];
+
+  const RULES = [
+    { id: 'speed',    emoji: '⏱️', name: 'Speed bonus',     note: 'Quick answers earn extra points' },
+    { id: 'mistakes', emoji: '💛', name: 'Mistakes count',  note: 'A wrong try costs a few points' },
+    { id: 'bonus',    emoji: '⭐', name: 'Hard sums pay more', note: 'Bigger questions are worth extra' },
+    { id: 'music',    emoji: '🎵', name: 'Jungle music',    note: 'A tune plays while you explore' }
+  ];
+
+  const STEPS = ['avatar', 'difficulty', 'scoring'];
+
+  let host = null;
+  let draft = null;
+  let finish = null;
+  let step = 0;
+
+  /* `settings` is read, never written: the caller decides what to do with the
+     copy handed back through onDone. */
+  function open(hostElement, settings, onDone) {
+    host = hostElement;
+    draft = Object.assign({}, settings);
+    finish = onDone;
+    step = 0;
+    host.onclick = handleClick;
+    render();
+  }
+
+  function render() {
+    host.innerHTML = `
+      <div class="setup-step">
+        ${stepMarkup()}
+      </div>
+      <div class="setup-dots" aria-hidden="true">
+        ${STEPS.map((unused, i) => `<span class="setup-dot${i === step ? ' on' : ''}"></span>`).join('')}
+      </div>
+      <div class="setup-nav">
+        ${step > 0 ? '<button class="ghost-button" type="button" data-nav="back">← Back</button>' : ''}
+        <button class="big-button" type="button" data-nav="next">${step === STEPS.length - 1 ? "Let's go! 🌿" : 'Next →'}</button>
+      </div>`;
+
+    if (STEPS[step] === 'avatar') {
+      Character.renderChoices(host.querySelector('#setup-avatars'), draft.avatar);
+    }
+  }
+
+  function stepMarkup() {
+    if (STEPS[step] === 'avatar') {
+      return `
+        <h2>Who is exploring?</h2>
+        <p class="setup-note">This is you on the trail.</p>
+        <div id="setup-avatars" class="avatar-grid"></div>`;
+    }
+    if (STEPS[step] === 'difficulty') {
+      return `
+        <h2>How tricky should the sums be?</h2>
+        <p class="setup-note">You can change this later from your explorer card.</p>
+        <div class="choice-list">${LEVELS.map(levelRow).join('')}</div>`;
+    }
+    return `
+      <h2>Points and music</h2>
+      <p class="setup-note">All optional — the trail plays just fine with everything off.</p>
+      <div class="choice-list">${RULES.map(ruleRow).join('')}</div>`;
+  }
+
+  function levelRow(level) {
+    const on = draft.difficulty === level.id;
+    return `
+      <button class="choice-row${on ? ' selected' : ''}" type="button"
+              data-level="${level.id}" aria-pressed="${on}">
+        <span class="choice-emoji" aria-hidden="true">${level.emoji}</span>
+        <span class="choice-text">
+          <strong>${level.name}</strong>
+          <span>${level.note}</span>
+        </span>
+        <span class="choice-mark" aria-hidden="true">${on ? '✓' : ''}</span>
+      </button>`;
+  }
+
+  function ruleRow(rule) {
+    const on = !!draft[rule.id];
+    return `
+      <button class="choice-row${on ? ' selected' : ''}" type="button"
+              data-rule="${rule.id}" aria-pressed="${on}">
+        <span class="choice-emoji" aria-hidden="true">${rule.emoji}</span>
+        <span class="choice-text">
+          <strong>${rule.name}</strong>
+          <span>${rule.note}</span>
+        </span>
+        <span class="choice-switch${on ? ' on' : ''}" aria-hidden="true"></span>
+      </button>`;
+  }
+
+  function handleClick(event) {
+    const target = event.target.closest('[data-avatar], [data-level], [data-rule], [data-nav]');
+    if (!target) return;
+
+    Sound.pop();
+
+    if (target.dataset.avatar) {
+      draft.avatar = target.dataset.avatar;
+      Character.setAvatar(draft.avatar);          // so the preview redraws as chosen
+      return render();
+    }
+    if (target.dataset.level) {
+      draft.difficulty = target.dataset.level;
+      return render();
+    }
+    if (target.dataset.rule) {
+      draft[target.dataset.rule] = !draft[target.dataset.rule];
+      if (target.dataset.rule === 'music') Sound.setMusicOn(draft.music);
+      return render();
+    }
+    if (target.dataset.nav === 'back') {
+      step = Math.max(0, step - 1);
+      return render();
+    }
+    if (step < STEPS.length - 1) {
+      step += 1;
+      return render();
+    }
+    draft.done = true;
+    finish(draft);
+  }
+
+  return { open };
+})();

--- a/projects/jungle-addition/js/share.js
+++ b/projects/jungle-addition/js/share.js
@@ -1,0 +1,106 @@
+/* share.js — turn a finished stop, or the whole adventure, into a few lines a
+   grown-up can send to a grandparent. Building the text is pure and testable;
+   getting it out of the browser is three fallbacks deep, because the share
+   sheet, the clipboard API and file:// pages disagree about what exists. */
+window.Share = (function () {
+  'use strict';
+
+  const HOME = 'https://ranjithkumarshetty.github.io/projects/jungle-addition/';
+  const TITLE = 'Jungle Addition Adventure';
+
+  /* One cleared stop, told in the order a parent reads it: what, how well,
+     how long. `session` is what the level screen tracked while playing. */
+  function levelSummary(session) {
+    const s = session || {};
+    const lines = [
+      `🌿 ${TITLE} — Stop ${s.stopId}: ${s.stopName}`,
+      `${s.avatarEmoji || '🐯'} ${s.avatarName || 'Tiger'} · ${titleCase(s.difficulty || 'medium')}`,
+      [
+        `🧮 ${count(s.solved, 'sum')} solved`,
+        `⏱ ${formatDuration(s.elapsedMs)}`,
+        `❌ ${count(s.mistakes, 'slip')}`
+      ].join(' · ')
+    ];
+    if (s.stars) lines.push(`⭐ ${s.stars}`);
+    if (s.points) lines.push(`🏅 ${s.points} points this stop`);
+    lines.push(`Play along: ${HOME}`);
+    return lines.join('\n');
+  }
+
+  /* Everything so far — the version worth sending once, at the end of a week. */
+  function adventureSummary(state, stats, totalStops) {
+    const s = state || {};
+    const totals = stats || { answered: 0, missed: 0, accuracy: 100 };
+    const settings = s.settings || {};
+    return [
+      `🌿 ${TITLE}`,
+      `${settings.avatarEmoji || '🐯'} ${settings.avatarName || 'Tiger'} the ${s.rank || 'Cub'} · ${titleCase(settings.difficulty || 'medium')}`,
+      `🗺 ${(s.clearedStops || []).length} of ${totalStops || 20} stops cleared`,
+      `🧮 ${count(totals.answered, 'sum')} solved · ✅ ${totals.accuracy}% first try · ❌ ${count(totals.missed, 'slip')}`,
+      `🏅 ${s.score || 0} points · 🐾 ${count(s.friends, 'friend')} · 🎖 ${count((s.badges || []).length, 'badge')}`,
+      `Play along: ${HOME}`
+    ].join('\n');
+  }
+
+  /* Short and spoken-sounding: "48s", "2m 14s", "1h 3m". */
+  function formatDuration(ms) {
+    const totalSeconds = Math.max(0, Math.round((ms || 0) / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours) return `${hours}h ${minutes}m`;
+    if (minutes) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
+  }
+
+  /* Native share sheet first — on a tablet that is the whole point. Clipboard
+     next, and a hidden textarea last for file:// pages where neither exists.
+     Resolves with how it went so the caller can say the right thing. */
+  function send(text) {
+    if (navigator.share) {
+      return navigator.share({ title: TITLE, text })
+        .then(() => ({ ok: true, how: 'shared' }))
+        .catch(err => (err && err.name === 'AbortError')
+          ? { ok: false, how: 'cancelled' }
+          : copy(text));
+    }
+    return copy(text);
+  }
+
+  function copy(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text)
+        .then(() => ({ ok: true, how: 'copied' }))
+        .catch(() => legacyCopy(text));
+    }
+    return Promise.resolve(legacyCopy(text));
+  }
+
+  function legacyCopy(text) {
+    try {
+      const box = document.createElement('textarea');
+      box.value = text;
+      box.setAttribute('readonly', '');
+      box.style.position = 'fixed';
+      box.style.opacity = '0';
+      document.body.appendChild(box);
+      box.select();
+      const done = document.execCommand('copy');
+      box.remove();
+      return { ok: done, how: done ? 'copied' : 'failed' };
+    } catch (err) {
+      return { ok: false, how: 'failed' };
+    }
+  }
+
+  function count(value, noun) {
+    const n = value || 0;
+    return `${n} ${noun}${n === 1 ? '' : 's'}`;
+  }
+
+  function titleCase(word) {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  }
+
+  return { HOME, levelSummary, adventureSummary, formatDuration, send };
+})();

--- a/projects/jungle-addition/tests.html
+++ b/projects/jungle-addition/tests.html
@@ -24,6 +24,8 @@
      tests/suite.js so `node tools/run-tests.js` runs the very same ones. -->
 <script src="js/facts.js"></script>
 <script src="js/progress.js"></script>
+<script src="js/score.js"></script>
+<script src="js/share.js"></script>
 <script src="js/character.js"></script>
 <script src="js/route.js"></script>
 <script src="js/build.js"></script>

--- a/projects/jungle-addition/tests/suite.js
+++ b/projects/jungle-addition/tests/suite.js
@@ -470,7 +470,217 @@
       eq(Badges.earnedCount(), Badges.total(), 'unreachable badges: ' +
         Badges.BADGES.filter(b => !Progress.hasBadge(b.id)).map(b => b.id).join(', '));
     });
+
+    /* ---- difficulty ------------------------------------------------------
+       Every test here runs inside atDifficulty(), which puts the dial back
+       where it found it — the rest of the suite reads the roster at medium. */
+
+    test('an unknown difficulty falls back to medium', () => {
+      atDifficulty('bananas', () => eq(Facts.getDifficulty(), 'medium'));
+    });
+
+    test('easy asks for two addends everywhere', () => {
+      atDifficulty('easy', () => {
+        Facts.STOPS.forEach(raw => {
+          const config = Facts.stop(raw.id);
+          ok(!config.pick || config.pick <= 2, `stop ${raw.id} still picks ${config.pick}`);
+          ok(!config.compound, `stop ${raw.id} is still compound`);
+          Facts.poolForStop(raw.id).forEach(addends => {
+            eq(addends.length, 2, `stop ${raw.id}: ${addends.join('+')} is not a pair`);
+          });
+        });
+      });
+    });
+
+    /* The gentler pool is a second source of facts, so it needs the same range
+       check the medium pool gets — an easy stop must still be that stop. */
+    test('the easy pool stays inside each stop declared answer range', () => {
+      atDifficulty('easy', () => {
+        Facts.STOPS.forEach(raw => {
+          Facts.poolForStop(raw.id).forEach(addends => {
+            const total = addends.reduce((a, b) => a + b, 0);
+              ok(total >= raw.min && total <= raw.max,
+              `stop ${raw.id}: ${addends.join('+')}=${total} outside ${raw.min}..${raw.max}`);
+          });
+        });
+      });
+    });
+
+    test('hard puts near-miss distractors on every stop', () => {
+      atDifficulty('hard', () => {
+        Facts.STOPS.forEach(raw => ok(Facts.stop(raw.id).tight, `stop ${raw.id} is not tight`));
+      });
+    });
+
+    test('easy spreads the wrong answers apart, hard crowds them in', () => {
+      atDifficulty('easy', () => {
+        Facts.buildOptions(10, seeded(3)).forEach(option => {
+          ok(option === 10 || Math.abs(option - 10) >= 2, `${option} sits next to the answer`);
+        });
+      });
+      atDifficulty('hard', () => {
+        ok(Facts.buildOptions(10, seeded(3)).includes(11), 'hard must offer the near miss');
+      });
+    });
+
+    test('an explicit spread overrides the difficulty default', () => {
+      atDifficulty('easy', () => {
+        ok(Facts.buildOptions(10, seeded(3), 'tight').includes(11));
+      });
+    });
+
+    /* ---- avatars ---------------------------------------------------------- */
+
+    test('setAvatar ignores an id that is not on the roster', () => {
+      const before = Character.getAvatar();
+      eq(Character.setAvatar('dragon'), 'tiger', 'unknown avatars fall back to the tiger');
+      eq(Character.avatarInfo('panda').emoji, '🐼');
+      Character.setAvatar(before);
+    });
+
+    test('every avatar draws every growth stage in its own colours', () => {
+      const before = Character.getAvatar();
+      Character.AVATARS.forEach(avatar => {
+        for (let stage = 0; stage < Character.STAGES.length; stage++) {
+          const svg = Character.markupFor(avatar.id, stage);
+          ok(svg.indexOf(avatar.fur) !== -1, `${avatar.id} stage ${stage} lost its palette`);
+          ok(svg.indexOf(`cub-stage-${stage}`) !== -1, `${avatar.id} stage ${stage} mislabelled`);
+        }
+        const top = Character.markupFor(avatar.id, Character.STAGES.length - 1);
+        ok(top.indexOf('cub-crown') !== -1, `${avatar.id} never gets the crown`);
+      });
+      eq(Character.getAvatar(), before, 'drawing an avatar must not select it');
+    });
+
+    /* ---- score.js --------------------------------------------------------- */
+
+    const EASY_SUM = { answer: 5, addends: [2, 3] };
+    const HARD_SUM = { answer: 14, addends: [5, 4, 5] };
+    const OFF = { speed: false, mistakes: false, bonus: false };
+
+    test('with every rule off a question is worth the base, however it went', () => {
+      eq(Score.forQuestion(EASY_SUM, {}, { attempts: 1, elapsedMs: 500 }, OFF).points, Score.BASE);
+      eq(Score.forQuestion(HARD_SUM, { tight: true }, { attempts: 5, elapsedMs: 90000 }, OFF).points,
+        Score.BASE, 'a slow, messy answer still pays the base');
+    });
+
+    test('the speed bonus pays only on a first-try answer', () => {
+      const rules = { speed: true, mistakes: false, bonus: false };
+      const quick = Score.forQuestion(EASY_SUM, {}, { attempts: 1, elapsedMs: 1000 }, rules);
+      ok(quick.points > Score.BASE, 'a fast first try earns extra');
+      eq(Score.forQuestion(EASY_SUM, {}, { attempts: 2, elapsedMs: 1000 }, rules).points, Score.BASE,
+        'a fast second try earns nothing extra');
+      eq(Score.forQuestion(EASY_SUM, {}, { attempts: 1, elapsedMs: 60000 }, rules).points, Score.BASE,
+        'a slow first try earns nothing extra');
+    });
+
+    test('the hard-question bonus reads the roster judgement of what is hard', () => {
+      const rules = { speed: false, mistakes: false, bonus: true };
+      eq(Score.forQuestion(EASY_SUM, {}, { attempts: 1 }, rules).points, Score.BASE,
+        'a small two-addend sum is not a hard question');
+      const hard = Score.forQuestion(HARD_SUM, { tight: true }, { attempts: 1 }, rules);
+      ok(hard.points > Score.BASE, 'a big three-addend sum on a tricky stop pays more');
+      eq(hard.parts.filter(part => part.points > 0).length, 4,
+        'base, big answer, three numbers and tricky stop');
+    });
+
+    /* The whole promise of the scoring: trying again is never worth nothing. */
+    test('points never fall below the floor however many tries it took', () => {
+      const rules = { speed: false, mistakes: true, bonus: false };
+      eq(Score.forQuestion(EASY_SUM, {}, { attempts: 12 }, rules).points, Score.MIN_POINTS);
+    });
+
+    test('rulesFrom keeps the bonus on and the punishing rules off by default', () => {
+      eq(Score.rulesFrom({}), { speed: false, mistakes: false, bonus: true });
+      eq(Score.rulesFrom(), { speed: false, mistakes: false, bonus: true });
+      eq(Score.rulesFrom({ speed: true, bonus: false, avatar: 'fox' }),
+        { speed: true, mistakes: false, bonus: false }, 'unknown keys are dropped');
+    });
+
+    test('the perfect-stop bonus needs both a clean sweep and the bonus rule', () => {
+      ok(Score.stopBonus(true, { bonus: true }) > 0);
+      eq(Score.stopBonus(false, { bonus: true }), 0, 'a stop with a slip earns no lump sum');
+      eq(Score.stopBonus(true, { bonus: false }), 0, 'the rule is off');
+    });
+
+    test('describe names the rules in play, or says the scoring is relaxed', () => {
+      eq(Score.describe(OFF), 'relaxed scoring');
+      eq(Score.describe({ speed: true, mistakes: false, bonus: true }),
+        'speed bonus, hard-question bonus');
+    });
+
+    /* ---- share.js --------------------------------------------------------- */
+
+    test('durations read the way they are spoken', () => {
+      eq(Share.formatDuration(0), '0s');
+      eq(Share.formatDuration(48000), '48s');
+      eq(Share.formatDuration(134000), '2m 14s');
+      eq(Share.formatDuration(3780000), '1h 3m');
+      eq(Share.formatDuration(-500), '0s', 'a clock skew must not print a minus');
+    });
+
+    test('a stop summary carries the numbers a grown-up wants to send', () => {
+      const text = Share.levelSummary({
+        stopId: 3, stopName: 'Vine Bridge', avatarEmoji: '🦊', avatarName: 'Fox',
+        difficulty: 'easy', solved: 6, mistakes: 1, elapsedMs: 95000, points: 72, stars: '⭐⭐⭐'
+      });
+      ok(text.indexOf('Stop 3: Vine Bridge') !== -1, 'names the stop');
+      ok(text.indexOf('Easy') !== -1, 'names the difficulty');
+      ok(text.indexOf('6 sums solved') !== -1, 'counts the sums');
+      ok(text.indexOf('1 slip') !== -1, 'one slip, not one slips');
+      ok(text.indexOf('1m 35s') !== -1, 'says how long it took');
+      ok(text.indexOf(Share.HOME) !== -1, 'links back to the game');
+    });
+
+    test('an adventure summary reads sensibly from a blank save', () => {
+      const text = Share.adventureSummary(Progress.__test.blank(),
+        { answered: 0, missed: 0, accuracy: 100 }, 20);
+      ok(text.indexOf('0 of 20 stops cleared') !== -1);
+      ok(text.split('\n').length === 6, 'six lines, always');
+    });
+
+    /* ---- settings --------------------------------------------------------- */
+
+    test('settings survive a save and a load', () => {
+      Progress.__test.useStorage(fakeStorage());
+      Progress.reset();
+      Progress.updateSettings({ avatar: 'koala', difficulty: 'hard', speed: true, done: true });
+      const saved = Progress.settings();
+      Progress.load();
+      eq(Progress.settings(), saved);
+      eq(Progress.settings().avatar, 'koala');
+    });
+
+    test('a save cannot smuggle in settings the game does not know', () => {
+      const decoded = Progress.__test.decode(JSON.stringify({
+        version: 1,
+        settings: { avatar: 'fox', difficulty: 7, hacked: true }
+      }));
+      eq(decoded.settings.avatar, 'fox', 'a known value of the right type is kept');
+      eq(decoded.settings.difficulty, 'medium', 'a value of the wrong type falls back');
+      eq(Object.keys(decoded.settings), Object.keys(Progress.__test.blankSettings()),
+        'no extra keys, and always in the blank order');
+    });
+
+    test('the lifetime score only ever goes up', () => {
+      Progress.__test.useStorage(fakeStorage());
+      Progress.reset();
+      Progress.addScore(30);
+      eq(Progress.addScore(-100), 0, 'points can be taken off, but never past zero');
+      eq(Progress.get().score, 0);
+    });
   };
+
+  /* Run `fn` with the difficulty dial turned, then always turn it back. */
+  function atDifficulty(level, fn) {
+    const before = Facts.getDifficulty();
+    try {
+      Facts.setDifficulty(level);
+      fn();
+    } finally {
+      Facts.setDifficulty(before);
+    }
+  }
 
   /* ---- helpers ---------------------------------------------------------- */
 

--- a/projects/jungle-addition/tools/run-tests.js
+++ b/projects/jungle-addition/tools/run-tests.js
@@ -14,6 +14,9 @@ global.window = global;
 [
   'js/facts.js',
   'js/progress.js',
+  /* Pure arithmetic and pure string building — no DOM, no browser APIs. */
+  'js/score.js',
+  'js/share.js',
   /* character.js only touches the DOM through the markup string it returns. */
   'js/character.js',
   /* The three new mechanics only touch the DOM inside show(); their


### PR DESCRIPTION
## What

Five pieces of playtest feedback, in one pass. First launch now walks through a three-step setup — pick an avatar, pick a difficulty, pick how points work — and then goes to the map. Returning players skip straight to the map; a ⚙️ button on the Explorer Card reopens the wizard at any time.

- **Difficulty (easy / medium / hard).** Easy never asks a child to build a sum from three numbers: `pick: 3` becomes `pick: 2`, the route forks narrow from three stones to two, and the wrong answers sit further from the right one. Hard tightens the distractors to near-misses on every stop. Number ranges are untouched — an easy stop is still that stop, and there is a test pinning it.
- **Avatars.** Five animals — 🐯 Tiger, 🐼 Panda, 🦊 Fox, 🐨 Koala, 🐆 Leopard — sharing one SVG rig, each a palette plus ear and marking variants. All six growth stages work for all five.
- **Scoring rules.** Three switches: speed bonus, mistakes hurt the score, bonus for hard questions. Defaults are the gentle ones — bonus on, the two punishing rules off. Whatever the settings, points floor at 1 per question and the lifetime score never goes down.
- **Sharing.** A "Share my adventure" button on the Explorer Card and a share on every stop-clear overlay: sums solved, time taken, slips made, points and stars, as plain text through `navigator.share` with a clipboard fallback.
- **More animation and music.** A looping synthesized soundtrack with two moods (a calmer jungle loop, a faster one for the rescue stops), a happy/sad wobble on the cub keyed to the answer, and points that float up off the character as they are earned.

## Notes

- **Still no assets.** The music is a pentatonic loop over a walking bass built from a note table and WebAudio oscillators — no audio files, no images, no fonts. It sits at low gain so it stays under the speech.
- **Two independent switches.** 🎵 toggles music alone; 🔇 is the master and takes music, effects and speech with it. Fixed a bug found while wiring this up: the mute button silenced effects and speech but left the music loop running, because the music path deliberately bypasses the effects mute check.
- **Save format unchanged.** `jungleAddition.v1` stays at version 1 — a bump would blank every existing save. New settings default in `blank()` and are tolerated as absent when decoding. Decoding merges key-by-key against the blank by type, so an edited save cannot smuggle in unknown keys.
- **The emotional contract holds.** No timers, no lives, no game over, progress only ever moves forward. The speed bonus is a bonus and never a penalty; the mistakes rule is off unless a grown-up turns it on, and even then the floor holds.
- Setup steps, scoring rules and share text live in their own modules (`js/setup.js`, `js/score.js`, `js/share.js`) so the pure logic is testable without a DOM.

## Testing

- 62 logic tests, headless and in-browser from the same source (`node projects/jungle-addition/tools/run-tests.js`) — 21 new, covering difficulty tuning, avatar rendering, scoring rules, share formatting and settings round-trips
- Difficulty tests run inside a `try/finally` helper that restores the dial, so the pre-existing 41 still read the roster at medium
- Static sweep: every `getElementById` in `js/*.js` resolves to an id in `index.html`, and every cross-module `Namespace.member` call resolves to a real export — zero mismatches
- `node tools/bundle.js` rebuilds the single-file offline copy clean (18 files, 193.6 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
