### PR TITLE
feat(jungle-addition): Add a once-per-stop question swap and maths validation

### DIFF
--- a/projects/jungle-addition/css/styles.css
+++ b/projects/jungle-addition/css/styles.css
@@ -498,10 +498,44 @@ h1 span { display: block; color: var(--lime); text-shadow: 0 4px 0 #1c6b3f; }
 .game-host > :first-child { margin-block-start: auto; }
 .game-host > :last-child  { margin-block-end: auto; }
 
+/* ---- swap this question --------------------------------------------------- */
+
+/* Below the board, not in the level bar: the offer has to be readable to be
+   understood, and the bar is already full of round icons whose meaning a
+   five-year-old has to be told. It says how many are left because "one per
+   stop" is only a rule if he can see it running out. */
+.swap-bar {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px calc(10px + env(safe-area-inset-bottom, 0px));
+}
+
+.swap-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 64px;
+  padding: 0 22px;
+  border-radius: 32px;
+  background: rgba(255, 253, 245, .14);
+  color: var(--cream);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.swap-btn:active { background: rgba(255, 253, 245, .28); }
+
+/* Spent, not gone: the button stays put so the rule stays visible. */
+.swap-btn[disabled] { opacity: .45; }
+
 /* A short landscape window: shrink the decoration, never the board. */
 @media (max-height: 560px) {
   .level-cub { height: 54px; }
   .rescue-scene { height: 68px; }
+  /* The pill keeps its 64px: a smaller tap target is the one thing a short
+     window is not allowed to buy back. */
+  .swap-bar { padding-bottom: 6px; }
 }
 
 /* ---- prompt --------------------------------------------------------------- */

--- a/projects/jungle-addition/index.html
+++ b/projects/jungle-addition/index.html
@@ -107,6 +107,12 @@
     <div id="level-cub" class="level-cub" aria-hidden="true"></div>
     <div id="rescue-strip" class="rescue-strip" hidden></div>
     <main id="game-host" class="game-host"></main>
+    <div class="swap-bar">
+      <button id="btn-swap" class="swap-btn" type="button">
+        <span aria-hidden="true">🔄</span>
+        <span id="swap-label">Swap this question — 1 left</span>
+      </button>
+    </div>
   </section>
 
   <!-- Overlays ------------------------------------------------------------ -->
@@ -175,6 +181,7 @@
   <div id="balloons" class="effect-layer" aria-hidden="true"></div>
 
   <!-- Load order matters: plain scripts, no modules, so file:// just works. -->
+  <script src="js/verify.js"></script>
   <script src="js/facts.js"></script>
   <script src="js/progress.js"></script>
   <script src="js/score.js"></script>

--- a/projects/jungle-addition/js/balance.js
+++ b/projects/jungle-addition/js/balance.js
@@ -33,6 +33,11 @@ window.Balance = (function () {
        pan, not the left, so that is the one worth recording against him. */
     if (preload) problem.key = Facts.factKey([preload, needed]);
 
+    const weights = weightsFor(problem, needed);
+    Verify.report(`stop ${stop.id} scale`,
+      Verify.balanceRow(weights, needed, preload, problem.answer)
+        .concat(Verify.question(problem)));
+
     host.innerHTML = `
       <section class="balance" data-target="${problem.answer}"
                data-preload="${preload}" data-needed="${needed}"
@@ -50,7 +55,7 @@ window.Balance = (function () {
         </div>
         <p class="balance-ask">Make both sides the same. Step ${index + 1} of ${total}</p>
         <div class="weight-row">
-          ${weightsFor(problem, needed).map(weightMarkup).join('')}
+          ${weights.map(weightMarkup).join('')}
         </div>
         <div class="hint-area balance-hint" hidden></div>
       </section>`;

--- a/projects/jungle-addition/js/build.js
+++ b/projects/jungle-addition/js/build.js
@@ -18,6 +18,8 @@ window.Build = (function () {
     const values = treeFor(stop, problem);
     picked = [];
 
+    Verify.report(`stop ${stop.id} fruit tree`, Verify.buildTree(values, problem.answer, pick));
+
     host.innerHTML = `
       <section class="build" data-target="${problem.answer}" data-pick="${pick}">
         <div class="build-goal">

--- a/projects/jungle-addition/js/facts.js
+++ b/projects/jungle-addition/js/facts.js
@@ -271,26 +271,59 @@ window.Facts = (function () {
 
   /* ---- public ------------------------------------------------------------ */
 
+  /* Match boards must not show two cards with the same sum. Route forks read
+     their wrong stones off `options`, so distinct targets keep a stop from
+     asking for the same total twice in a row. */
+  function needsDistinctAnswers(game) {
+    return ['match', 'route'].includes(game);
+  }
+
+  /* The one place a question is assembled, so it is also the one place the
+     arithmetic is signed off before anything downstream can draw it. */
+  function problemFrom(addends, rng) {
+    const total = sum(addends);
+    const built = {
+      addends: shuffle(addends, rng),     // presentation order varies, key does not
+      answer: total,
+      key: factKey(addends),
+      options: buildOptions(total, rng)
+    };
+    built.options = Verify.fixChoices(built.options, total);
+    Verify.report('fact ' + built.key, Verify.question(built));
+    return built;
+  }
+
   function generateStop(stopId, missCounts, rng) {
     rng = rng || Math.random;
     missCounts = missCounts || {};
     const config = stop(stopId);
-
-    /* Match boards must not show two cards with the same sum. Route forks read
-       their wrong stones off `options`, so distinct targets keep a stop from
-       asking for the same total twice in a row. */
-    const needsDistinctAnswers = ['match', 'route'].includes(config.game);
-    const isAcceptable = needsDistinctAnswers
+    const isAcceptable = needsDistinctAnswers(config.game)
       ? (fact, chosen) => !chosen.some(c => sum(c) === sum(fact))
       : () => true;
 
     return sampleFacts(poolForStop(stopId), QUESTIONS_PER_STOP, missCounts, rng, isAcceptable)
-      .map(addends => ({
-        addends: shuffle(addends, rng),   // presentation order varies, key does not
-        answer: sum(addends),
-        key: factKey(addends),
-        options: buildOptions(sum(addends), rng)
-      }));
+      .map(addends => problemFrom(addends, rng));
+  }
+
+  /* One fresh question from the same stop, for the swap button. `avoid.keys`
+     are the facts already on this run and `avoid.answers` the totals that must
+     stay unique; each is relaxed in turn rather than returning nothing, because
+     a swap that does nothing is worse than a swap that repeats a sum. */
+  function replacement(stopId, avoid, rng) {
+    rng = rng || Math.random;
+    avoid = avoid || {};
+    const keys = avoid.keys || [];
+    const answers = avoid.answers || [];
+    const pool = poolForStop(stopId);
+
+    const unseen = pool.filter(addends =>
+      keys.indexOf(factKey(addends)) === -1 && answers.indexOf(sum(addends)) === -1);
+    const distinct = unseen.length
+      ? unseen
+      : pool.filter(addends => answers.indexOf(sum(addends)) === -1);
+    const usable = distinct.length ? distinct : pool;
+
+    return problemFrom(usable[Math.floor(rng() * usable.length)], rng);
   }
 
   return {
@@ -306,6 +339,8 @@ window.Facts = (function () {
     decompose,
     buildOptions,
     generateStop,
+    needsDistinctAnswers,
+    replacement,
     setDifficulty,
     getDifficulty,
     isHardProblem

--- a/projects/jungle-addition/js/games.js
+++ b/projects/jungle-addition/js/games.js
@@ -15,6 +15,11 @@ window.Games = (function () {
   const ADVANCE_AFTER_CORRECT = 950;
   const ADVANCE_AFTER_REVEAL = 2100;
 
+  /* One "not this one" per stop. Enough to walk away from a question that has
+     gone sour, few enough that it stays a choice rather than a way of skipping
+     every sum he does not fancy. */
+  const SWAPS_PER_STOP = 1;
+
   let active = null;   // the running session, or null between levels
 
   /* ---- session lifecycle --------------------------------------------------- */
@@ -30,6 +35,9 @@ window.Games = (function () {
       attempts: 0,
       typed: '',
       stepsDone: 0,
+      swapsLeft: SWAPS_PER_STOP,
+      resolved: false,     // true between a right answer and the next question
+      matched: {},         // match only: pairs already cleared on this board
       timers: []
     };
 
@@ -60,6 +68,7 @@ window.Games = (function () {
   /* Every completed question — right or revealed — advances one step. */
   function completeQuestion(problem, missedFirstTry, delay) {
     active.stepsDone += 1;
+    active.resolved = true;
     hook('onQuestionDone', problem, missedFirstTry, active.stepsDone);
 
     const finished = active.stepsDone >= active.problems.length;
@@ -70,6 +79,7 @@ window.Games = (function () {
         if (hooks.onComplete) hooks.onComplete();
       } else if (active.stop.game === 'match') {
         /* match handles its own board transitions */
+        active.resolved = false;
       } else {
         active.index += 1;
         active.attempts = 0;
@@ -102,6 +112,7 @@ window.Games = (function () {
          every pending animation, and only stop() knows when that happens. */
       defer: (fn, delay) => later(fn, delay)
     });
+    active.resolved = false;
     hook('onQuestionShown', problem, active.index);
   }
 
@@ -213,13 +224,17 @@ window.Games = (function () {
     const problem = active.problems[active.index];
     const game = active.stop.game;
     active.typed = '';
+    active.resolved = false;
     active.target = targetOf(problem, game);
 
     /* facts.js builds options around the total, which is the wrong quantity
        for Missing Number — rebuild them around the hidden addend. */
-    const options = game === 'missing'
-      ? Facts.buildOptions(active.target)
-      : problem.options;
+    const options = Verify.fixChoices(
+      game === 'missing' ? Facts.buildOptions(active.target) : problem.options,
+      active.target);
+
+    Verify.report(`stop ${active.stop.id} question ${active.index + 1}`,
+      Verify.question(problem, game).concat(Verify.choices(options, active.target)));
 
     active.host.innerHTML = `
       <div class="prompt">
@@ -321,6 +336,10 @@ window.Games = (function () {
 
     active.matchAttempts = {};
     active.selected = null;
+    active.resolved = false;
+
+    Verify.report(`stop ${active.stop.id} match board ${boardIndex + 1}`,
+      Verify.matchBoard(pairs));
 
     const expressions = shuffled(pairs.map((p, i) => ({ pair: p, id: `${boardIndex}-${i}` })));
     const results = shuffled(pairs.map((p, i) => ({ pair: p, id: `${boardIndex}-${i}` })));
@@ -330,15 +349,11 @@ window.Games = (function () {
       <div class="match-board">
         <div class="match-col">
           ${expressions.map(item =>
-            `<button class="card card-expr" type="button" data-id="${item.id}" data-kind="expr">
-               ${item.pair.addends.join(' + ')}
-             </button>`).join('')}
+            cardMarkup(item, 'expr', item.pair.addends.join(' + '))).join('')}
         </div>
         <div class="match-col">
           ${results.map(item =>
-            `<button class="card card-result" type="button" data-id="${item.id}" data-kind="result">
-               ${item.pair.answer}
-             </button>`).join('')}
+            cardMarkup(item, 'result', item.pair.answer)).join('')}
         </div>
       </div>`;
 
@@ -348,6 +363,17 @@ window.Games = (function () {
 
     Sound.speak('Match the sums!');
     hook('onQuestionShown', pairs[0], active.index);
+  }
+
+  /* A swap redraws the board mid-play, so pairs already cleared have to come
+     back cleared — losing them would hand back progress he has already made. */
+  function cardMarkup(item, kind, face) {
+    const done = active.matched[item.id];
+    return `
+      <button class="card card-${kind}${done ? ' matched' : ''}" type="button"
+              data-id="${item.id}" data-kind="${kind}"${done ? ' disabled' : ''}>
+        ${face}
+      </button>`;
   }
 
   function shuffled(list) {
@@ -395,6 +421,7 @@ window.Games = (function () {
       card.classList.add('matched');
       card.disabled = true;
     });
+    active.matched[expression.dataset.id] = true;
 
     Sound.correct();
     Sound.praise();
@@ -483,5 +510,64 @@ window.Games = (function () {
     }
   }
 
-  return { play, stop };
+  /* ---- swapping a question -------------------------------------------------
+     "I do not want this one" is a fair thing for a five-year-old to feel, and
+     letting him act on it beats letting him stall. The swap costs nothing —
+     no step, no mistake, no score — it simply deals a different sum. */
+
+  function swapsLeft() {
+    return active ? active.swapsLeft : 0;
+  }
+
+  function canSwap() {
+    return !!active && active.swapsLeft > 0 && !active.resolved;
+  }
+
+  function swapQuestion() {
+    if (!canSwap()) return false;
+
+    active.swapsLeft -= 1;
+    active.attempts = 0;
+
+    if (active.stop.game === 'match') {
+      swapMatchBoard();
+    } else {
+      active.problems[active.index] = replacementFor(active.index);
+      if (isDelegated(active.stop.game)) showDelegated();
+      else showBubbleQuestion();
+    }
+
+    Sound.pop();
+    hook('onSwap', swapsLeft());
+    return true;
+  }
+
+  /* Fresh, and still obeying the rules the stop was dealt under: no fact he has
+     already met here, and — where the mechanic needs unique totals — no sum
+     that clashes with the questions still on the board. */
+  function replacementFor(index) {
+    const distinct = Facts.needsDistinctAnswers(active.stop.game);
+    return Facts.replacement(active.stop.id, {
+      keys: active.problems.map(p => p.key),
+      answers: distinct
+        ? active.problems.filter((p, i) => i !== index).map(p => p.answer)
+        : []
+    });
+  }
+
+  /* On a match board the question is the whole board, so what changes is every
+     pair still on the table; the ones already matched stay matched. */
+  function swapMatchBoard() {
+    const boardIndex = Math.floor(active.stepsDone / 3);
+
+    for (let slot = 0; slot < 3; slot++) {
+      const index = boardIndex * 3 + slot;
+      if (index >= active.problems.length) break;
+      if (active.matched[`${boardIndex}-${slot}`]) continue;
+      active.problems[index] = replacementFor(index);
+    }
+    showMatchBoard();
+  }
+
+  return { play, stop, swapQuestion, swapsLeft };
 })();

--- a/projects/jungle-addition/js/main.js
+++ b/projects/jungle-addition/js/main.js
@@ -67,6 +67,8 @@ window.Main = (function () {
       pips: byId('level-pips'),
       levelCub: byId('level-cub'),
       gameHost: byId('game-host'),
+      swapButton: byId('btn-swap'),
+      swapLabel: byId('swap-label'),
 
       overlayClear: byId('overlay-clear'),
       clearTitle: byId('clear-title'),
@@ -113,6 +115,7 @@ window.Main = (function () {
     });
 
     el.backButton.addEventListener('click', leaveLevel);
+    el.swapButton.addEventListener('click', swapQuestion);
     el.muteButton.addEventListener('click', toggleMute);
     el.musicButton.addEventListener('click', toggleMusic);
     el.clearShare.addEventListener('click', shareLevel);
@@ -249,9 +252,30 @@ window.Main = (function () {
         onCorrect: handleCorrect,
         onWrong: handleWrong,
         onQuestionDone: handleQuestionDone,
+        onSwap: syncSwapButton,
         onComplete: finishLevel
       }
     });
+
+    syncSwapButton();
+  }
+
+  /* Swapping is free by design: no step taken, no mistake logged, and the clock
+     for the speed bonus restarts with the new question via onQuestionShown.
+     The new question reads itself out, so nothing is said about the swap. */
+  function swapQuestion() {
+    Games.swapQuestion();
+  }
+
+  function syncSwapButton() {
+    const left = Games.swapsLeft();
+    el.swapButton.disabled = left === 0;
+    el.swapLabel.textContent = left
+      ? `Swap this question — ${left} left`
+      : 'Swap used for this stop';
+    el.swapButton.setAttribute('aria-label', left
+      ? `Swap this question for a different one. ${left} swap left at this stop.`
+      : 'No swaps left at this stop');
   }
 
   function renderPips(done) {

--- a/projects/jungle-addition/js/route.js
+++ b/projects/jungle-addition/js/route.js
@@ -13,7 +13,9 @@ window.Route = (function () {
   function show(api) {
     const { host, stop, problem, index, total } = api;
     const target = problem.answer;
-    const values = shuffle([target].concat(distractorsFor(stop, problem)));
+    const stones = stonesFor(stop, problem);
+
+    Verify.report(`stop ${stop.id} route fork`, Verify.routeStones(stones, target));
 
     host.innerHTML = `
       <section class="route" data-target="${target}">
@@ -22,8 +24,7 @@ window.Route = (function () {
           <span class="sign-text">Cross to <strong>${target}</strong></span>
         </div>
         <div class="route-stones">
-          ${values.map(value =>
-            stoneMarkup(value, target, value === target ? problem.addends : null)).join('')}
+          ${stones.map(stone => stoneMarkup(stone, target)).join('')}
         </div>
         <div class="route-chest">
           <span class="chest">🧰</span>
@@ -39,14 +40,25 @@ window.Route = (function () {
     });
   }
 
-  /* Every stone shows its two addends, so reading it is the addition. The
+  /* The fork as data: each stone is a value and the split printed on it. The
      winning stone is given the problem's own split rather than a fresh one, so
      the fact he practises here is the fact recorded against him. */
-  function stoneMarkup(value, target, addends) {
-    const parts = addends || Facts.decompose(value);
+  function stonesFor(stop, problem) {
+    const target = problem.answer;
+    const stones = [{ value: target, addends: problem.addends }].concat(
+      distractorsFor(stop, problem).map(value => ({
+        value: value,
+        addends: Facts.decompose(value)
+      })));
+    return shuffle(stones);
+  }
+
+  /* Every stone shows its two addends, so reading it is the addition. */
+  function stoneMarkup(stone, target) {
+    const parts = stone.addends;
     return `
-      <button class="stone" type="button" data-value="${value}"
-              data-correct="${value === target}"
+      <button class="stone" type="button" data-value="${stone.value}"
+              data-correct="${stone.value === target}"
               aria-label="${parts.join(' plus ')}">
         <span class="stone-face">${STONE_EMOJI}</span>
         <span class="stone-expr">${parts.join(' + ')}</span>
@@ -131,5 +143,5 @@ window.Route = (function () {
     return out;
   }
 
-  return { show, distractorsFor };
+  return { show, stonesFor, distractorsFor };
 })();

--- a/projects/jungle-addition/js/verify.js
+++ b/projects/jungle-addition/js/verify.js
@@ -1,0 +1,175 @@
+/* verify.js — the maths referee.
+   Every board is checked here before it is drawn. The generators are small and
+   the roster is hand-written, so the failure worth guarding against is not a
+   crash: it is a question quietly going up with no right answer on it, or with
+   two. A five-year-old cannot tell the difference between "this is hard" and
+   "this is broken", so the game has to.
+
+   Pure functions, no DOM and no state, so the whole file runs in the suite. */
+window.Verify = (function () {
+  'use strict';
+
+  const MAX_TOTAL = 20;        // the number line this game lives on
+
+  /* ---- the checks ---------------------------------------------------------- */
+
+  /* The question itself: does the arithmetic hold, and is the thing we are about
+     to ask for a number he could actually give? */
+  function question(problem, game) {
+    const addends = problem && problem.addends;
+    if (!Array.isArray(addends) || addends.length < 2) return ['no addends'];
+
+    const faults = [];
+    if (!addends.every(isCount)) faults.push('addends are not whole counts: ' + addends.join(','));
+    if (total(addends) !== problem.answer) {
+      faults.push(`${addends.join('+')} makes ${total(addends)}, not ${problem.answer}`);
+    }
+    if (problem.answer > MAX_TOTAL) faults.push(`answer ${problem.answer} is off the number line`);
+
+    /* Missing Number shows the first addend, a blank and the total. A third
+       addend would vanish from the equation while still counting towards the
+       sum, leaving a question whose answer is not the one on the buttons. */
+    if (game === 'missing' && addends.length !== 2) {
+      faults.push(`missing-number question has ${addends.length} addends`);
+    }
+    return faults;
+  }
+
+  /* Whatever the board, the answer has to be on it exactly once. */
+  function choices(values, target) {
+    if (!Array.isArray(values) || !values.length) return ['no choices'];
+
+    const faults = [];
+    if (!values.every(isCount)) faults.push('choices are not whole counts: ' + values.join(','));
+
+    const hits = values.filter(value => value === target).length;
+    if (hits !== 1) faults.push(`${hits} of ${values.length} choices equal ${target}`);
+
+    const repeats = repeated(values);
+    if (repeats.length) faults.push('repeated choice: ' + repeats.join(','));
+    return faults;
+  }
+
+  /* The one repair worth making automatically. A choice list that has lost its
+     answer is the single failure a child cannot work around — every other flaw
+     leaves the question solvable — so it is rebuilt rather than shown. Sound
+     lists are returned untouched, keeping their shuffled order. */
+  function fixChoices(values, target) {
+    if (!choices(values, target).length) return values;
+
+    const wanted = Array.isArray(values) && values.length ? values.length : 4;
+    const others = [];
+    (Array.isArray(values) ? values : []).forEach(value => {
+      if (isCount(value) && value !== target && others.indexOf(value) === -1) others.push(value);
+    });
+    for (let filler = 0; others.length < wanted - 1; filler++) {
+      if (filler !== target && others.indexOf(filler) === -1) others.push(filler);
+    }
+
+    /* Slotted by the answer rather than pushed to the front, so a repaired
+       board does not advertise itself by always holding the answer first. */
+    const fixed = others.slice(0, wanted - 1);
+    fixed.splice(target % wanted, 0, target);
+    return fixed;
+  }
+
+  /* Treasure Route stones carry their own sum, so each label has to be true as
+     well as the fork having exactly one stone that crosses. */
+  function routeStones(stones, target) {
+    const faults = choices(stones.map(stone => stone.value), target);
+    stones.forEach(stone => {
+      if (!Array.isArray(stone.addends) || stone.addends.length < 2
+          || !stone.addends.every(isCount)) {
+        faults.push(`stone ${stone.value} has no readable sum`);
+      } else if (total(stone.addends) !== stone.value) {
+        faults.push(`stone ${stone.addends.join('+')} is labelled ${stone.value}`);
+      }
+    });
+    return faults;
+  }
+
+  /* Build the Sum has no list of answers to check — the basket is fillable or it
+     is not. Repeated fruit is fine and expected (a double needs two of them);
+     what matters is that some handful of the right size makes the total, and
+     that no single fruit is already it. */
+  function buildTree(values, answer, pick) {
+    const faults = [];
+    if (!Array.isArray(values) || !values.length) return ['no fruit'];
+    if (!values.every(isCount)) faults.push('fruit are not whole counts: ' + values.join(','));
+    if (values.some(value => value < 1)) faults.push('a fruit is worth nothing');
+
+    const tooBig = values.filter(value => value >= answer);
+    if (tooBig.length) faults.push(`fruit ${tooBig.join(',')} already reach ${answer}`);
+    if (!subsetExists(values, pick, answer)) {
+      faults.push(`no ${pick} of ${values.join(',')} make ${answer}`);
+    }
+    return faults;
+  }
+
+  /* Both sides of the scale have to be able to meet: the missing weight must be
+     a real one, and it must be in the row. */
+  function balanceRow(values, needed, preload, answer) {
+    const faults = choices(values, needed);
+    if (preload + needed !== answer) {
+      faults.push(`${preload} + ${needed} makes ${preload + needed}, not ${answer}`);
+    }
+    if (needed < 1) faults.push('nothing left to add to the pan');
+    if (preload < 0) faults.push(`negative preload ${preload}`);
+    return faults;
+  }
+
+  /* Two cards showing the same total would make one of the pairings arbitrary,
+     and a board can only be finished if every pairing is forced. */
+  function matchBoard(pairs) {
+    const faults = [];
+    pairs.forEach(pair => { push(faults, question(pair, 'match')); });
+
+    const repeats = repeated(pairs.map(pair => pair.answer));
+    if (repeats.length) faults.push('two sums on this board both make ' + repeats.join(','));
+    return faults;
+  }
+
+  /* ---- reporting ----------------------------------------------------------- */
+
+  /* None of this should ever fire. When it does the grown-up sees it, because a
+     banner is easier to explain than a sum that will not come out. */
+  function report(where, faults) {
+    if (!faults.length) return true;
+    const message = `maths check failed at ${where}: ${faults.join('; ')}`;
+    if (typeof console !== 'undefined' && console.warn) console.warn(message);
+    if (window.reportProblem) window.reportProblem(message);
+    return false;
+  }
+
+  /* ---- helpers ------------------------------------------------------------- */
+
+  function isCount(value) {
+    return typeof value === 'number' && isFinite(value) && value >= 0 && value % 1 === 0;
+  }
+
+  function total(list) {
+    return list.reduce((running, n) => running + n, 0);
+  }
+
+  function repeated(list) {
+    return list.filter((value, i) => list.indexOf(value) !== i);
+  }
+
+  function push(faults, more) {
+    more.forEach(fault => faults.push(fault));
+  }
+
+  /* Boards are six values and picks are two or three, so the plain recursive
+     search is both the clearest way to say it and fast enough. */
+  function subsetExists(values, size, wanted) {
+    if (size === 0) return wanted === 0;
+    if (size > values.length) return false;
+    return values.some((value, i) => subsetExists(values.slice(i + 1), size - 1, wanted - value));
+  }
+
+  return {
+    question, choices, fixChoices,
+    routeStones, buildTree, balanceRow, matchBoard,
+    subsetExists, report
+  };
+})();

--- a/projects/jungle-addition/tests.html
+++ b/projects/jungle-addition/tests.html
@@ -22,6 +22,7 @@
 
 <!-- Only the modules with no DOM dependency. The tests themselves live in
      tests/suite.js so `node tools/run-tests.js` runs the very same ones. -->
+<script src="js/verify.js"></script>
 <script src="js/facts.js"></script>
 <script src="js/progress.js"></script>
 <script src="js/score.js"></script>

--- a/projects/jungle-addition/tests/suite.js
+++ b/projects/jungle-addition/tests/suite.js
@@ -669,6 +669,194 @@
       eq(Progress.addScore(-100), 0, 'points can be taken off, but never past zero');
       eq(Progress.get().score, 0);
     });
+
+    /* ---- verify.js -------------------------------------------------------- */
+
+    test('a question is passed only when its arithmetic actually holds', () => {
+      eq(Verify.question({ addends: [3, 4], answer: 7 }), []);
+      ok(Verify.question({ addends: [3, 4], answer: 8 }).length, 'a wrong total is caught');
+      ok(Verify.question({ addends: [3], answer: 3 }).length, 'one addend is not a sum');
+      ok(Verify.question({ addends: [1.5, 1.5], answer: 3 }).length, 'halves are not counts');
+      ok(Verify.question({ addends: [14, 12], answer: 26 }).length, 'off the number line');
+    });
+
+    /* The equation for Missing Number prints one addend, a blank and the total,
+       so a third addend would vanish from the screen while still counting
+       towards the sum — the blank would then have no right answer. */
+    test('a missing-number question may only ever have two addends', () => {
+      eq(Verify.question({ addends: [2, 3, 4], answer: 9 }, 'missing').length, 1);
+      eq(Verify.question({ addends: [2, 3, 4], answer: 9 }, 'critters'), []);
+    });
+
+    test('a set of choices must hold the answer once, and once only', () => {
+      eq(Verify.choices([4, 7, 9, 2], 7), []);
+      ok(Verify.choices([4, 8, 9, 2], 7).length, 'the answer is missing');
+      ok(Verify.choices([7, 7, 9, 2], 7).length, 'the answer is on two buttons');
+      ok(Verify.choices([4, 4, 7, 2], 7).length, 'a wrong answer is on two buttons');
+      ok(Verify.choices([], 7).length, 'nothing to tap');
+    });
+
+    test('a broken choice list is repaired, a sound one is left exactly as it was', () => {
+      const sound = [4, 7, 9, 2];
+      ok(Verify.fixChoices(sound, 7) === sound, 'same array, same shuffled order');
+
+      const fixed = Verify.fixChoices([4, 8, 9, 2], 7);
+      eq(fixed.length, 4, 'still four buttons');
+      eq(Verify.choices(fixed, 7), [], 'and now solvable');
+      ok(fixed[0] !== 7, 'the answer is not parked in the first slot');
+    });
+
+    test('every stone on a fork carries the sum it claims to', () => {
+      eq(Verify.routeStones([
+        { value: 7, addends: [3, 4] },
+        { value: 5, addends: [1, 4] }
+      ], 7), []);
+      ok(Verify.routeStones([
+        { value: 7, addends: [3, 4] },
+        { value: 5, addends: [1, 3] }
+      ], 7).length, 'a stone labelled with the wrong split is caught');
+    });
+
+    test('a fruit tree has to be fillable, and no single fruit may already be it', () => {
+      eq(Verify.buildTree([2, 5, 1, 3, 4, 6], 7, 2), []);
+      eq(Verify.buildTree([4, 4, 1, 2, 3, 5], 8, 2), [], 'doubles need two of the same fruit');
+      ok(Verify.buildTree([1, 2, 3, 4, 5, 6], 7, 3).length === 0);
+      ok(Verify.buildTree([1, 1, 1, 2, 2, 2], 9, 2).length, 'no two of these make nine');
+      ok(Verify.buildTree([7, 1, 2, 3, 4, 5], 7, 2).length, 'a fruit worth the whole total');
+    });
+
+    test('a scale is only fair when both pans can be made to meet', () => {
+      eq(Verify.balanceRow([3, 4, 5, 6], 5, 0, 5), []);
+      eq(Verify.balanceRow([3, 4, 5, 6], 5, 4, 9), [], 'a compound stop preloads a pan');
+      ok(Verify.balanceRow([3, 4, 6, 7], 5, 0, 5).length, 'the weight is not in the row');
+      ok(Verify.balanceRow([3, 4, 5, 6], 5, 4, 8).length, 'the pans cannot be squared');
+      ok(Verify.balanceRow([0, 1, 2, 3], 0, 5, 5).length, 'nothing left to add');
+    });
+
+    test('a match board may not show the same total twice', () => {
+      eq(Verify.matchBoard([
+        { addends: [1, 2], answer: 3 },
+        { addends: [2, 2], answer: 4 }
+      ]), []);
+      ok(Verify.matchBoard([
+        { addends: [1, 2], answer: 3 },
+        { addends: [0, 3], answer: 3 }
+      ]).length, 'two cards both make three');
+    });
+
+    test('report says yes to a clean board and no to a faulty one', () => {
+      ok(Verify.report('nowhere', []) === true);
+      const said = [];
+      const wasReport = window.reportProblem, wasWarn = console.warn;
+      window.reportProblem = message => said.push(message);
+      console.warn = () => {};        // the fault is deliberate; do not shout about it
+      try {
+        ok(Verify.report('stop 1', ['1+1 makes 2, not 3']) === false);
+      } finally {
+        window.reportProblem = wasReport;
+        console.warn = wasWarn;
+      }
+      eq(said.length, 1, 'the grown-up is told, loudly');
+      ok(said[0].indexOf('stop 1') !== -1 && said[0].indexOf('not 3') !== -1,
+        'and told where and what');
+    });
+
+    /* The whole point of the referee: nothing the roster can deal may fail it. */
+    test('every question the roster can deal passes its own checks', () => {
+      Facts.DIFFICULTIES.forEach(level => {
+        atDifficulty(level, () => {
+          Facts.STOPS.forEach(stop => {
+            const config = Facts.stop(stop.id);
+            for (let run = 0; run < 8; run++) {
+              const problems = Facts.generateStop(stop.id, {}, seeded(run * 13 + stop.id));
+              problems.forEach(p => {
+                eq(Verify.question(p, config.game), [],
+                  `${level} stop ${stop.id}: ${p.addends.join('+')}=${p.answer}`);
+                eq(Verify.choices(p.options, p.answer), [],
+                  `${level} stop ${stop.id} options ${p.options} for ${p.answer}`);
+              });
+              if (config.game === 'match') {
+                eq(Verify.matchBoard(problems.slice(0, 3)), [], `${level} stop ${stop.id} board 1`);
+                eq(Verify.matchBoard(problems.slice(3, 6)), [], `${level} stop ${stop.id} board 2`);
+              }
+            }
+          });
+        });
+      });
+    });
+
+    test('every board the three drawn mechanics build passes its own checks', () => {
+      Facts.DIFFICULTIES.forEach(level => {
+        atDifficulty(level, () => {
+          Facts.STOPS.forEach(stop => {
+            const config = Facts.stop(stop.id);
+            if (!['route', 'build', 'balance'].includes(config.game)) return;
+
+            for (let run = 0; run < 8; run++) {
+              Facts.generateStop(stop.id, {}, seeded(run * 3 + stop.id)).forEach(p => {
+                const where = `${level} stop ${stop.id} for ${p.addends.join('+')}`;
+                if (config.game === 'route') {
+                  eq(Verify.routeStones(Route.stonesFor(config, p), p.answer), [], where);
+                } else if (config.game === 'build') {
+                  const pick = config.pick || 2;
+                  eq(Verify.buildTree(Build.treeFor(config, p), p.answer, pick), [], where);
+                } else {
+                  const preload = config.compound ? Balance.preloadFor(p) : 0;
+                  const needed = p.answer - preload;
+                  eq(Verify.balanceRow(Balance.weightsFor(p, needed), needed, preload, p.answer),
+                    [], where);
+                }
+              });
+            }
+          });
+        });
+      });
+    });
+
+    /* ---- swapping a question ---------------------------------------------- */
+
+    test('a swap deals a sound question from the same stop', () => {
+      Facts.STOPS.forEach(stop => {
+        const config = Facts.stop(stop.id);
+        const pool = Facts.poolForStop(stop.id).map(Facts.factKey);
+        for (let run = 0; run < 5; run++) {
+          const fresh = Facts.replacement(stop.id, {}, seeded(run * 5 + stop.id));
+          eq(Verify.question(fresh, config.game), [], `stop ${stop.id} swap`);
+          ok(pool.indexOf(fresh.key) !== -1, `stop ${stop.id} swapped outside its own pool`);
+        }
+      });
+    });
+
+    test('a swap avoids the facts and totals already on the board', () => {
+      const asked = Facts.generateStop(4, {}, seeded(99));
+      const keys = asked.map(p => p.key);
+      const answers = asked.map(p => p.answer);
+
+      for (let run = 0; run < 20; run++) {
+        const fresh = Facts.replacement(4, { keys, answers }, seeded(run * 31 + 7));
+        ok(keys.indexOf(fresh.key) === -1, `swapped back to ${fresh.key}`);
+        ok(answers.indexOf(fresh.answer) === -1, `swapped to a repeated total ${fresh.answer}`);
+      }
+    });
+
+    /* A pool can genuinely run out of unseen facts. Handing back nothing would
+       leave the child staring at the question he asked to be rid of, so the
+       rules are relaxed in turn instead. */
+    test('a swap still deals something when every fact has been seen', () => {
+      const everything = Facts.poolForStop(1);
+      const fresh = Facts.replacement(1, {
+        keys: everything.map(Facts.factKey),
+        answers: everything.map(f => f.reduce((a, b) => a + b, 0))
+      }, seeded(3));
+      eq(Verify.question(fresh), [], 'and what it deals is still a real sum');
+    });
+
+    test('only route and match need their totals to stay unique', () => {
+      eq(Facts.needsDistinctAnswers('match'), true);
+      eq(Facts.needsDistinctAnswers('route'), true);
+      eq(Facts.needsDistinctAnswers('critters'), false);
+      eq(Facts.needsDistinctAnswers('build'), false);
+    });
   };
 
   /* Run `fn` with the difficulty dial turned, then always turn it back. */

--- a/projects/jungle-addition/tools/run-tests.js
+++ b/projects/jungle-addition/tools/run-tests.js
@@ -12,6 +12,8 @@ const ROOT = path.join(__dirname, '..');
 global.window = global;
 
 [
+  /* First: facts.js signs every question off through it as it is built. */
+  'js/verify.js',
   'js/facts.js',
   'js/progress.js',
   /* Pure arithmetic and pure string building — no DOM, no browser APIs. */


### PR DESCRIPTION
## What

Two follow-ups from the last round of playtesting.

**Swap this question — once per stop.** A labelled pill sits under the board (`Swap this question — 1 left`), and once spent it stays put, greyed, reading `Swap used for this stop`, so the rule is visible rather than remembered. The swap is free by design: no step counted, no mistake logged, no points lost, and the speed-bonus clock restarts with the new question. It deals a fresh fact from the same stop's pool, avoiding the facts already asked on this run and — where the mechanic needs unique totals (Match, Route) — the totals still on the board. It cannot fire in the gap between a right answer and the next question. On a Match board the "question" is the whole board, so the swap redeals only the pairs still unmatched; pairs already cleared come back cleared.

**A maths referee before anything is drawn.** New `js/verify.js`: pure, DOM-free functions that sign off every board before it renders. It checks the addends are whole counts that actually make the answer, that the answer is within the game's number line, and that it sits on the buttons exactly once with no repeats. Each mechanic gets its own check — that every route stone carries the sum printed on it, that some `pick`-sized handful of fruit reaches the total and no single fruit already is it, that the two pans of the scale can be made to meet, and that no Match board shows the same total twice. A choice list that has lost its answer is repaired in place (and the answer is slotted by value, not pushed to the front, so a repaired board doesn't advertise itself). Anything else raises the existing `reportProblem` banner, because a grown-up can explain a banner but not a sum that won't come out.

## Notes

- One real latent bug is now encoded as a rule: the Missing Number equation renders as `addends[0] + ? = total`, so a third addend would vanish from the screen while still counting towards the sum — leaving a blank with no right answer. `Verify.question(problem, 'missing')` now faults on that.
- Missing Number builds its choices around the total, which is the wrong quantity for a hidden addend; those options are now rebuilt around the actual target before the verifier sees them.
- No new files beyond `js/verify.js`, no dependencies, no version bump — saved progress loads unchanged.
- The swap pill keeps its 64px tap target even in the short-landscape media query; only the padding around it shrinks.

## Testing

- `node tools/run-tests.js` — **77 passed, 0 failed** (62 before, 15 new).
- The new tests cover each verifier in isolation, plus two roster-wide sweeps: every question every stop can deal across all three difficulties, and every route fork, fruit tree and weight row those questions produce, all asserted to verify clean. The swap is covered for staying inside its stop's pool, honouring the avoid-lists, and still dealing something when the pool is exhausted.
- `node tools/bundle.js` — bundles 19 files cleanly.
- **Not done: no browser smoke test.** The Playwright MCP server is unreachable from this session, so the swap button, its disabled state and the mid-board Match redraw have been verified by logic tests and reading only, not by clicking through the game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
